### PR TITLE
add an option to specify threshold for averaged photon count

### DIFF
--- a/ptycho/+engines/+GPU/+initialize/load_from_p.m
+++ b/ptycho/+engines/+GPU/+initialize/load_from_p.m
@@ -68,6 +68,15 @@ function [self, param, p] = load_from_p(param, p)
         param.TV_lambda = p.TV_lambda;         
     end
     
+    if isfield(p,'avg_photon_threshold') && p.avg_photon_threshold>=0
+        avg_photon_threshold = p.avg_photon_threshold;
+    else %default
+        if isfield(param,'beam_source') && strcmp(param.beam_source,'electron')
+            avg_photon_threshold = 0.0001;
+        else
+            avg_photon_threshold = 0.01;
+        end
+    end
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     
     %%
@@ -315,8 +324,9 @@ function [self, param, p] = load_from_p(param, p)
         self.diffraction(mask_ind) = self.diffraction(min(mask_ind+1, numel(self.diffraction))); 
     end
     
-    if any(sum(sum(self.diffraction)) / prod(p.asize) < 0.01)
-        error('%i patterns has average photon count < 0.01', mean(sum(sum(self.diffraction)) / prod(p.asize) < 0.01))
+    low_photon_count_dp = sum(sum(self.diffraction)) / prod(p.asize) < avg_photon_threshold;
+    if any(low_photon_count_dp)
+        error('%0.2f%% diffraction patterns has average photon count < %f', sum(low_photon_count_dp)/size(self.diffraction,3)*100, avg_photon_threshold)
     end
     
     %% automatic data centering / flipping / tilted plane correction 

--- a/ptycho/ptycho_electron_simulation_template.m
+++ b/ptycho/ptycho_electron_simulation_template.m
@@ -335,6 +335,8 @@ eng.save_results_every = Niter_save_results;
 eng.save_phase_image = true;
 eng.save_probe_mag = true;
 eng.save_sub_objects = false;
+eng.avg_photon_threshold = 0; %Added by YJ. Check averaged photon count per pixel during pre-processing. Stop if smaller than the threshold (default = 0.01);
+
 resultDir = p.base_path;
 eng.fout =  generateResultDir(eng, resultDir);
 [eng.fout, p.suffix] =  generateResultDir(eng, resultDir);


### PR DESCRIPTION
The GPU engines check averaged photon count during initialization and stop if the value is too low.
However, the default threshold, 0.01, can too high for electron ptycho data or simulated data.

Add a new variable to allow user to specify the threshold.
eng.avg_photon_threshold = 0; %Check averaged photon count per pixel during pre-processing. Stop if smaller than the threshold (default = 0.01);
Default: 
0.0001 for electron ptycho data or 0.01 for other data

example script: ptycho_electron_simulation_template.m 
