### PR TITLE
add an option to specify the maximum object size allowed on GPU during multi-slice reconstruction

### DIFF
--- a/ptycho/+engines/+GPU_MS/+initialize/get_defaults.m
+++ b/ptycho/+engines/+GPU_MS/+initialize/get_defaults.m
@@ -13,6 +13,7 @@ function [param] = get_defaults
     param.compress_data = true;  % apply online compress on the GPU data 
     param.gpu_id = []; % default GPU id, [] means choosen by matlab
     param.check_gpu_load = true;
+    param.obj_size_limit_on_gpu = inf; % maximum object size (in MB) allowed on gpu. Automatically use cpu if exceed the limit.
     
     %% basic recontruction parameters 
     %% PIE 


### PR DESCRIPTION
Add an option to specify the maximum object size allowed on GPU.

New variable for the GPU_MS engine: 
eng.obj_size_limit_on_gpu = inf; 
% maximum object size (in MB) allowed on gpu. Automatically switches to CPU if object's size exceeds the limit.
It's only used during multi-layer regularization, but can be extended to other steps if needed.