### PR TITLE
add an option to flip directions for "raster" scan type

### DIFF
--- a/ptycho/+scans/+positions/matlab_pos.m
+++ b/ptycho/+scans/+positions/matlab_pos.m
@@ -64,9 +64,17 @@ for ii = 1:p.numscans
         case 'raster'
             %for iy=0:p.scan.ny
             %    for ix=0:p.scan.nx
-            for iy=1:p.scan.ny %modified by YJ. seems odd to begin with 0...
-                for ix=1:p.scan.nx
-                    xy = [iy * p.scan.step_size_y, ix *  p.scan.step_size_x] + ...
+            scan_order_x = 1:p.scan.nx;
+            scan_order_y = 1:p.scan.ny;
+            if isfield(p.scan,'flip_x') && p.scan.flip_x
+                scan_order_x = fliplr(scan_order_x);
+            end
+            if isfield(p.scan,'flip_y') && p.scan.flip_y
+                scan_order_y = fliplr(scan_order_y);
+            end
+            for iy=1:length(scan_order_y) %modified by YJ. seems odd to begin with 0...
+                for ix=1:length(scan_order_x)
+                    xy = [scan_order_y(iy) * p.scan.step_size_y, scan_order_x(ix) * p.scan.step_size_x] + ...
                             randn(1,2).*p.scan.step_randn_offset.*[ p.scan.step_size_y,  p.scan.step_size_x];
                     positions_real(end+1,:) = xy; %#ok<AGROW>
                 end
@@ -83,6 +91,7 @@ for ii = 1:p.numscans
                     positions_real(end+1,:) = xy; %#ok<AGROW>
                 end
             end
+            
         case 'round_roi'
             rmax = sqrt((p.scan.lx/2)^2 + (p.scan.ly/2)^2);
             nr = 1 + floor(rmax/p.scan.dr);
@@ -123,8 +132,6 @@ for ii = 1:p.numscans
                     positions_real(end+1,:) = xy;
                 end
             end
-            
-            
             
         case 'custom'
             fn_splt = strsplit(p.scan.custom_positions_source,'.');

--- a/ptycho/ptycho_electron_nature_comm.m
+++ b/ptycho/ptycho_electron_nature_comm.m
@@ -126,6 +126,8 @@ p.   scan.nx = N_scan_x;        %size(dp,3)                                  % r
 p.   scan.ny = N_scan_y;                                          % raster scan: number of steps in y
 p.   scan.step_size_x = scan_step_size;                               % raster scan: step size (grid spacing)
 p.   scan.step_size_y = scan_step_size;                               % raster scan: step size (grid spacing)
+p.   scan.flip_x = true;                                    % raster scan: flip scan order in x direction
+p.   scan.flip_y = true;                                    % raster scan: flip scan order in y direction
 p.   scan.step_randn_offset = 0;                            % raster scan: relative random offset from the ideal periodic grid to avoid the raster grid pathology 
 p.   scan.b = 0;                                            % fermat: angular offset
 p.   scan.n_max = 1e4;                                      % fermat: maximal number of points generated 
@@ -323,7 +325,7 @@ eng. mirror_objects = false;           % mirror objects, useful for 0/180deg sca
 % custom data adjustments, useful for offaxis ptychography
 eng.auto_center_data = false;           % autoestimate the center of mass from data and shift the diffraction patterns so that the average center of mass corresponds to center of mass of the provided probe 
 eng.auto_center_probe = false;          % center the probe position in real space before reconstruction is started 
-eng.custom_data_flip = [1,1,1];         % apply custom flip of the data [fliplr, flipud, transpose]  - can be used for quick testing of reconstruction with various flips or for reflection ptychography 
+eng.custom_data_flip = [0,0,1];         % apply custom flip of the data [fliplr, flipud, transpose]  - can be used for quick testing of reconstruction with various flips or for reflection ptychography 
 eng.apply_tilted_plane_correction = ''; % if any(p.sample_rotation_angles([1,2]) ~= 0),  this option will apply tilted plane correction. (a) 'diffraction' apply correction into the data, note that it is valid only for "low NA" illumination  Gardner, D. et al., Optics express 20.17 (2012): 19050-19059. (b) 'propagation' - use tilted plane propagation, (c) '' - will not apply any correction 
 
 %% added by YJ


### PR DESCRIPTION
Add two variables for raster scan position (used when p.src_positions = 'matlab_pos' and scan.type = 'raster') : 
p scan.flip_x = true; % flip scan order in x direction 
p.scan.flip_y = true; % flip scan order in y direction

This can be useful for experimental electron ptychography data. 
The alternative is to flip diffraction patterns using the eng.custom_data_flip = [0,0,0] variable in GPU(_MS) engines.

Example script: ptycho_electron_nature_comm.m