### PR TITLE
use proper probe initialization for arbitrary-path fly-scan ptychography

### DIFF
--- a/ptycho/+engines/+GPU/LSQML.m
+++ b/ptycho/+engines/+GPU/LSQML.m
@@ -360,17 +360,13 @@ function [self, cache, fourier_error] = LSQML(self,par,cache,fourier_error,iter)
            end
            for ll = 1:par.Nmodes
                % allow variation of the modes intensity 
-                aa = sum2( self.probe{ll} .* conj( probe_new));
-                bb = sum2(abs(probe_new).^2);
-                %size(aa)
-                %size(bb)
+                aa = sum2(self.probe{ll} .* conj(probe_new));
+                bb = sum2(abs(probe_new).^2);                
                 proj(ll,1,:) = real(aa./ bb) ;
-
-                %proj(ll,1,:) = real(sum2( self.probe{ll} .* conj( probe_new)) ./ sum2(abs(probe_new).^2)) ;
-                %self.probe{ll} = proj(ll,1,:) .* probe_new;
+                self.probe{ll} = proj(ll,1,:) .* probe_new;
                 
                 % assume constant intensity 
-                  self.probe{ll} =  probe_new;
+                  %self.probe{ll} =  probe_new;
            end
        end
     end


### PR DESCRIPTION
Add a feature that initializes the probe modes (1:par.Nmodes) for arbitrary-path fly-scan ptychography with the primary probe mode. This helps with the convergence when varying probe modes are used.

Now that the convergence issue is fixed, also switch back to varying probe modes from constant modes, which probably won't be used in the future.