### PR TITLE
add more options for position interpolation in arbitrary-path fly-scan ptychography

### DIFF
--- a/ptycho/+engines/+GPU/+initialize/get_defaults.m
+++ b/ptycho/+engines/+GPU/+initialize/get_defaults.m
@@ -5,7 +5,6 @@
 % returns: 
 % ++ param       structure containing parameters for the engines 
 
-
 function [param] = get_defaults
 
     %%%%%%%%%%%%%% GPU SETTINGS %%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -98,6 +97,10 @@ function [param] = get_defaults
     % fly scans 
     param.flyscan_offset = 0; 
     param.flyscan_dutycycle = 1;
+    param.flyscan_trajectory = 'line';    % Added by YJ. Specify trajectory type for arbitrary-path fly-scan:
+                                          %'line' (default): line scan with big jumps. 
+                                          %'continuous': contiuous path. 
+                                          %'external': load positions from external files
     rng('default');
     rng('shuffle');
     

--- a/ptycho/+engines/+GPU/+initialize/prepare_flyscan_positions.m
+++ b/ptycho/+engines/+GPU/+initialize/prepare_flyscan_positions.m
@@ -10,75 +10,88 @@
 % returns: 
 % ++ self      structure containing inputs: e.g. current reconstruction results, data, mask, positions, pixel size, ..
 
-
 function self = prepare_flyscan_positions(self, par)
 import engines.GPU.GPU_wrapper.*
 import math.*
 import utils.*
 import plotting.*
-
-    jumps = diff(self.probe_positions_0);
-    step = median(jumps,1);
-    jumps = sum(abs(jumps),2);
-    % empirical condition 
-    jumps = find(jumps > 10*median(jumps));
     
-    if length(jumps) < par.Nscans
-        % assume that smooth path is used 
-       %% ADVANCED FLY SCAN - SPIRAL
-        for ii = 1:par.Nscans
-            assert(~any(isfinite(par.probe_position_search)), 'Position refinement and fly scans not suported')
-
-            ind =  self.reconstruct_ind{ii};
-            pos = self.probe_positions_0(ind,:);
-            [ang, rad] = cart2pol(pos(:,1)-pos(1,1), pos(:,2)-pos(1,2)); 
-            ang = unwrap(ang); 
-            % get interpolate d positions of the sub probes 
-            ang_all = ang + (par.flyscan_offset -0.5+linspace(0,par.flyscan_dutycycle*(par.Nmodes-1)/par.Nmodes, par.Nmodes)   ).*[diff(ang);0]; 
-            rad_all = interp1(ang, rad, ang_all, 'pchip'); 
-            [X,Y] = pol2cart(ang_all, rad_all);
+    switch par.flyscan_trajectory
+        case 'line' % line scan w. big jumps
+            jumps = diff(self.probe_positions_0);
+            %step = median(jumps,1);
+            jumps = sum(abs(jumps),2);
+            % empirical condition
+            jumps = find(jumps > 10*median(jumps));
+            %% ADVANCED FLY SCAN - LINE SCAN. Modified by YJ for more general use
+            % interpolate the other modes into new positions 
+            pos = self.modes{1}.probe_positions;
+            %pos(:,1): horizontal positions in pixels
+            %pos(:,2): vertical positions in pixels 
+            N_lines = length(jumps)+1;
+            jumps = [0; jumps; length(pos(:,1))];
             for ll = 1:par.Nmodes
-                    self.modes{ll}.probe_positions(ind,:) = pos(1,1:2) + [X(:,ll), Y(:,ll)];
-                %if iter == 1;  self.probe{ll} = self.probe{1}; end
+                ratio = par.flyscan_dutycycle*(ll-1)/par.Nmodes;
+                pos_temp = pos;
+                p_lb = 1;
+                for i=1:N_lines
+                    x = 1:(jumps(i+1)-jumps(i));
+                    x_interp = (x(1)+ratio):1:(x(end)+ratio);
+                    p_ub = p_lb + length(x)-1;
+
+                    pos_temp(p_lb:p_ub,1) = interp1(x,pos(p_lb:p_ub,1),x_interp,'pchip');
+                    pos_temp(p_lb:p_ub,2) = interp1(x,pos(p_lb:p_ub,2),x_interp,'pchip');  
+                    self.modes{ll}.probe_positions = pos_temp;
+                    p_lb = p_ub+1;
+                end
             end
-        end
-    else
-        %% ADVANCED FLY SCAN - LINE SCAN 
-        %disp('FLY SCAN - LINE SCAN')
-        % interpolate the other modes into new positions 
-        pos = self.modes{1}.probe_positions;
-        %modified by YJ
-        %pos(:,1): horizontal positions in pixels
-        %pos(:,2): vertical positions in pixels
-        %TODO: suport non-rectangular grid
-        for ll = 1:par.Nmodes
-            ratio = par.flyscan_dutycycle*(ll-1)/par.Nmodes;
-            pos_temp = pos;
-            Ny = length(jumps)+1;
-            Nx = length(pos)/Ny;
-            x = 1:Nx;
-            x_interp = (1+ratio):1:(Nx+ratio);
-            
-            for i=1:Ny
-                p_lb = (i-1)*Nx+1;
-                p_ub = i*Nx;
-                pos_temp(p_lb:p_ub,1) = interp1(x,pos(p_lb:p_ub,1),x_interp,'pchip');
-                pos_temp(p_lb:p_ub,2) = interp1(x,pos(p_lb:p_ub,2),x_interp,'pchip');  
-                self.modes{ll}.probe_positions = pos_temp;
-            end
-        end
         
-        %{ 
-        %MO's code - may have some bugs
-        for ll = 1:par.Nmodes
-            ratio = par.flyscan_dutycycle*(ll-1)/par.Nmodes;
-            self.modes{ll}.probe_positions = pos(min((1:self.Npos)+1,self.Npos),:)*ratio + (1-ratio)*pos;
-            if ~isempty(jumps)
-                % expected step continuation
-                self.modes{ll}.probe_positions(jumps,:) = bsxfun(@plus, self.modes{ll}.probe_positions(jumps-1,:),step);
+            %{
+            %MO's code - may have some bugs
+            for ll = 1:par.Nmodes
+                ratio = par.flyscan_dutycycle*(ll-1)/par.Nmodes;
+                self.modes{ll}.probe_positions = pos(min((1:self.Npos)+1,self.Npos),:)*ratio + (1-ratio)*pos;
+                if ~isempty(jumps)
+                    % expected step continuation
+                    self.modes{ll}.probe_positions(jumps,:) = bsxfun(@plus, self.modes{ll}.probe_positions(jumps-1,:),step);
+                end
             end
-        end
-        %}
-    end
+            %}
+        case 'continuous' % assume that smooth path is used 
+            for ii = 1:par.Nscans
+                ind = self.reconstruct_ind{ii};
+                pos = self.probe_positions_0(ind,:);
+                pos_temp = pos;
+
+                for ll = 1:par.Nmodes
+                    ratio = par.flyscan_dutycycle*(ll-1)/par.Nmodes;
+                    x = 1:size(pos,1);
+                    x_interp = (x(1)+ratio):1:(x(end)+ratio);
+
+                    pos_temp(:,1) = interp1(x,pos(:,1),x_interp,'pchip');
+                    pos_temp(:,2) = interp1(x,pos(:,2),x_interp,'pchip');  
+                    self.modes{ll}.probe_positions(ind,:) = pos_temp;                    
+                end
+                %{
+                % MO's code - seems only work for spiral trajectory
+                assert(~any(isfinite(par.probe_position_search)), 'Position refinement and fly scans not suported')
+
+                ind = self.reconstruct_ind{ii};
+                pos = self.probe_positions_0(ind,:);
+                [ang, rad] = cart2pol(pos(:,1)-pos(1,1), pos(:,2)-pos(1,2)); 
+                ang = unwrap(ang);
+                % get interpolate d positions of the sub probes 
+                ang_all = ang + (par.flyscan_offset -0.5+linspace(0,par.flyscan_dutycycle*(par.Nmodes-1)/par.Nmodes, par.Nmodes)   ).*[diff(ang);0]; 
+                rad_all = interp1(ang, rad, ang_all, 'pchip'); 
+                [X,Y] = pol2cart(ang_all, rad_all);
+                for ll = 1:par.Nmodes
+                        self.modes{ll}.probe_positions(ind,:) = pos(1,1:2) + [X(:,ll), Y(:,ll)];
+                    %if iter == 1;  self.probe{ll} = self.probe{1}; end
+                end
+                %}
+            end
+        case 'external' % use positions from external measurements
     
+    
+    end
 end

--- a/ptycho/+engines/+GPU/LSQML.m
+++ b/ptycho/+engines/+GPU/LSQML.m
@@ -308,7 +308,6 @@ function [self, cache, fourier_error] = LSQML(self,par,cache,fourier_error,iter)
             probe_update_sum(:,:,uniq_p_ind,1) = probe_update_sum(:,:,uniq_p_ind,1) + m_probe_update / Nind; 
         end
 
-     
    end
    %if iter>0
    %    disp(size(fourier_error(iter,:)))
@@ -323,9 +322,7 @@ function [self, cache, fourier_error] = LSQML(self,par,cache,fourier_error,iter)
        verbose(2,'Probe amplitude corrected by %.3g',probe_amp_corr)
        return
    end
-  
-   
-     
+
    % applying single update emulates behaviour of the original ML method ->
    % provides better noise robustness 
    % advantage is that less memory is needed and no linesearch is required
@@ -361,12 +358,12 @@ function [self, cache, fourier_error] = LSQML(self,par,cache,fourier_error,iter)
            for ll = 1:par.Nmodes
                % allow variation of the modes intensity 
                 aa = sum2(self.probe{ll} .* conj(probe_new));
-                bb = sum2(abs(probe_new).^2);                
+                bb = sum2(abs(probe_new).^2);     
                 proj(ll,1,:) = real(aa./ bb) ;
                 self.probe{ll} = proj(ll,1,:) .* probe_new;
                 
                 % assume constant intensity 
-                  %self.probe{ll} =  probe_new;
+                %self.probe{ll} =  probe_new;
            end
        end
     end

--- a/ptycho/+engines/+GPU/ptycho_solver.m
+++ b/ptycho/+engines/+GPU/ptycho_solver.m
@@ -206,14 +206,17 @@ for iter =  (1-par.initial_probe_rescaling):par.number_iterations
         aux = online_FSC_estimate(self, par, cache, fsc_score(end,:), iter); 
         fsc_score(end+1,1:size(aux,1), 1:size(aux,2)) = aux; 
     end   
-    %% ADVANCED FLY SCAN. disabled by YJ. it's already calculated init_solver.m . probably useful with position correction?
+    %% ADVANCED FLY SCAN. 
+    % disabled by YJ. seems redundant since it's already calculated init_solver.m .
+    % probably useful with position correction?
+    %{
     if  is_used(par, 'fly_scan')
         if iter == 1
            disp(['== AVG fly scan step ', num2str( median(sqrt(sum(diff(self.probe_positions_0).^2,1)))  )]) 
         end
         self = prepare_flyscan_positions(self, par); 
     end
-    
+    %}
     %% update current probe positions (views)
     if iter <= 1 || iter >= par.probe_position_search
         %%%%%%%%  crop only ROI of the full image for subsequent calculations  %%%%%%%%%% 


### PR DESCRIPTION
1. Modify the interpolation code introduced in PR #31 to work with an imperfect line scan grid. For example, missing points at the end of the line.
2. Add interpolation method for continuous scan trajectory.
3. Add a new variable in the GPU engine:
eng.flyscan_trajectory = 'line';    
%Specify trajectory type for arbitrary-path fly-scan:
%'line' (default): line scan with big jumps. 
%'continuous': contiuous path. 
%'external': load positions from external files. To be implemented in the future.

Example script: ptycho_lamni_2020c3_APS_C_arbitrary_fly.m