### PR TITLE
add asymmetry in outputs and omit nan in fourier_error_out

### DIFF
--- a/ptycho/+engines/+GPU/ptycho_solver.m
+++ b/ptycho/+engines/+GPU/ptycho_solver.m
@@ -504,7 +504,7 @@ for iter =  (1-par.initial_probe_rescaling):par.number_iterations
         else
             fourier_error_out = Ggather(fourier_error);
         end
-        outputs.fourier_error_out = mean(fourier_error_out,2);
+        outputs.fourier_error_out = mean(fourier_error_out,2,'omitnan'); % omit nan by ZC
         %save the lastest error of all dp
         try
             iter_error = find(~isnan(mean(fourier_error_out,2)));
@@ -559,6 +559,7 @@ for iter =  (1-par.initial_probe_rescaling):par.number_iterations
         outputs.relative_pixel_scale = self.modes{1}.scales;
         outputs.rotation =  self.modes{1}.rotation;
         outputs.shear =   self.modes{1}.shear;
+        outputs.asymmetry = self.modes{1}.asymmetry; % added by ZC
         outputs.z_distance = self.modes{1}.distances;
 
         % 

--- a/ptycho/+engines/+GPU_MS/ptycho_solver.m
+++ b/ptycho/+engines/+GPU_MS/ptycho_solver.m
@@ -548,7 +548,7 @@ for iter =  (1-par.initial_probe_rescaling):par.number_iterations
         else
             fourier_error_out = Ggather(fourier_error);
         end
-        outputs.fourier_error_out = mean(fourier_error_out,2);
+        outputs.fourier_error_out = mean(fourier_error_out,2,'omitnan'); % omit nan by ZC
         %disp(outputs.fourier_error_out(1:4))
         %save the lastest error of all dp
         try
@@ -606,6 +606,7 @@ for iter =  (1-par.initial_probe_rescaling):par.number_iterations
         outputs.relative_pixel_scale = self.modes{1}.scales;
         outputs.rotation =  self.modes{1}.rotation;
         outputs.shear =   self.modes{1}.shear;
+        outputs.asymmetry =   self.modes{1}.asymmetry; % added by ZC
         outputs.z_distance = self.modes{1}.distances;
 
         % 


### PR DESCRIPTION

 1. add geometric asymmetry in outputs both in +GPU and +GPU_MS
 2. for averaging fourier_error_out (to outputs) over all diffractions, add 'omitnan' to ignore possible nans from some position. updates in ptycho_solver.m in +GPU and +GPU_MS
