### PR TITLE
save interpolated positions in arbitrary-path fly-scan reconstruction

### DIFF
--- a/ptycho/+engines/+GPU/ptycho_solver.m
+++ b/ptycho/+engines/+GPU/ptycho_solver.m
@@ -207,7 +207,7 @@ for iter =  (1-par.initial_probe_rescaling):par.number_iterations
         fsc_score(end+1,1:size(aux,1), 1:size(aux,2)) = aux; 
     end   
     %% ADVANCED FLY SCAN. 
-    % disabled by YJ. seems redundant since it's already calculated init_solver.m .
+    % disabled by YJ. seems redundant since it's already calculated init_solver.m
     % probably useful with position correction?
     %{
     if  is_used(par, 'fly_scan')
@@ -538,7 +538,13 @@ for iter =  (1-par.initial_probe_rescaling):par.number_iterations
         end
             
         % scan positions
-        outputs.probe_positions = self.modes{1}.probe_positions;
+        if is_used(par, 'fly_scan')
+            for ll=1:length(self.modes)
+                outputs.probe_positions(:,:,ll) = self.modes{ll}.probe_positions;
+            end
+        else
+            outputs.probe_positions = self.modes{1}.probe_positions;
+        end
         try %probe_positions_model may not exist if geom refinement is not enabled
             outputs.probe_positions_model = self.modes{1}.probe_positions_model;
         catch

--- a/ptycho/diagnosis/view_arbitrary_path_fly_positions.m
+++ b/ptycho/diagnosis/view_arbitrary_path_fly_positions.m
@@ -1,0 +1,10 @@
+%view_arbitrary_path_fly_positions.m
+%show scan positions in arbitrary-path fly-scan reconstruction
+
+%% load a matlab recon file
+figure
+hold on
+for i=1:size(outputs.probe_positions,3)
+    scatter(outputs.probe_positions(:,1,i)*p.dx_spec(1),outputs.probe_positions(:,2,i)*p.dx_spec(1),'.','DisplayName',num2str(i)); axis image
+end
+legend


### PR DESCRIPTION
Add a feature to save positions in all modes in arbitrary-path fly-scan reconstruction. This is useful for examing the 
interpolated positions.
Also, add a script to plot all interpolated positions.