### PR TITLE
add an option to switch strategies for combining probe modes in arbitrary-path fly-scan ptychography

### DIFF
--- a/ptycho/+engines/+GPU/+initialize/get_defaults.m
+++ b/ptycho/+engines/+GPU/+initialize/get_defaults.m
@@ -97,6 +97,7 @@ function [param] = get_defaults
     % fly scans 
     param.flyscan_offset = 0; 
     param.flyscan_dutycycle = 1;
+    param.flyscan_intensity = 'varying';  % Added by YJ. Specify how to combine flyscan modes: 'varying' (default) or 'constant'.
     param.flyscan_trajectory = 'line';    % Added by YJ. Specify trajectory type for arbitrary-path fly-scan:
                                           %'line' (default): line scan with big jumps. 
                                           %'continuous': contiuous path. 


### PR DESCRIPTION
Allow users to specify strategies for combining probe modes in arbitrary-path fly-scan ptychography.
Add a new variable in the GPU engine:
eng.flyscan_intensity = 'varying';  % Added by YJ. Specify how to combine flyscan modes: 'varying' (default) or 'constant'

Example script: ptycho_simulation_flyscan_dose_FSC.m