### PR TITLE
save more info about the initial object, probe, and positions in GPU engines' output

### DIFF
--- a/ptycho/+engines/+GPU/ptycho_solver.m
+++ b/ptycho/+engines/+GPU/ptycho_solver.m
@@ -589,7 +589,6 @@ for iter =  (1-par.initial_probe_rescaling):par.number_iterations
         
         % store initial object file if given by an external file
         if ~isempty(par.p.initial_iterate_object_file{1})
-        	disp(par.p.initial_iterate_object_file)
             p.init_object_file = par.p.initial_iterate_object_file;
         end
         % store initial position file

--- a/ptycho/+engines/+GPU_MS/ptycho_solver.m
+++ b/ptycho/+engines/+GPU_MS/ptycho_solver.m
@@ -645,7 +645,7 @@ for iter =  (1-par.initial_probe_rescaling):par.number_iterations
         p.obj_init_param.init_layer_interp = par.init_layer_interp;
         p.obj_init_param.init_layer_append_mode = par.init_layer_append_mode;
         p.obj_init_param.init_layer_scaling_factor = par.init_layer_scaling_factor;
-        if ~isempty(par.p.initial_iterate_object_file) % if initial object is from a given file
+        if ~isempty(par.p.initial_iterate_object_file{1}) % if initial object is from a given file
         	p.init_object_file = par.p.initial_iterate_object_file;
             if isfield(par.p,'multiple_layers_obj')
                 p.obj_init_param.multiple_layers_obj = par.p.multiple_layers_obj;


### PR DESCRIPTION
Save more info about the initial object, probe, and positions in GPU engines' output.
1. Save the file name of the initial probe and positions if they are given by external files.
2. Save the probe function at the start of the main loop (after initial pre-processing).
