### PR TITLE
rename p.scan.type options in the matlab and hdf5 scan position reader

### DIFF
--- a/ptycho/+scans/+positions/matlab_pos.m
+++ b/ptycho/+scans/+positions/matlab_pos.m
@@ -1,61 +1,6 @@
 %MATLAB_POS calculate scan parameters based on the values set in the
 %template
 
-% Academic License Agreement
-%
-% Source Code
-%
-% Introduction 
-% •	This license agreement sets forth the terms and conditions under which the PAUL SCHERRER INSTITUT (PSI), CH-5232 Villigen-PSI, Switzerland (hereafter "LICENSOR") 
-%   will grant you (hereafter "LICENSEE") a royalty-free, non-exclusive license for academic, non-commercial purposes only (hereafter "LICENSE") to use the cSAXS 
-%   ptychography MATLAB package computer software program and associated documentation furnished hereunder (hereafter "PROGRAM").
-%
-% Terms and Conditions of the LICENSE
-% 1.	LICENSOR grants to LICENSEE a royalty-free, non-exclusive license to use the PROGRAM for academic, non-commercial purposes, upon the terms and conditions 
-%       hereinafter set out and until termination of this license as set forth below.
-% 2.	LICENSEE acknowledges that the PROGRAM is a research tool still in the development stage. The PROGRAM is provided without any related services, improvements 
-%       or warranties from LICENSOR and that the LICENSE is entered into in order to enable others to utilize the PROGRAM in their academic activities. It is the 
-%       LICENSEE’s responsibility to ensure its proper use and the correctness of the results.”
-% 3.	THE PROGRAM IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR 
-%       A PARTICULAR PURPOSE AND NONINFRINGEMENT OF ANY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS. IN NO EVENT SHALL THE LICENSOR, THE AUTHORS OR THE COPYRIGHT 
-%       HOLDERS BE LIABLE FOR ANY CLAIM, DIRECT, INDIRECT OR CONSEQUENTIAL DAMAGES OR OTHER LIABILITY ARISING FROM, OUT OF OR IN CONNECTION WITH THE PROGRAM OR THE USE 
-%       OF THE PROGRAM OR OTHER DEALINGS IN THE PROGRAM.
-% 4.	LICENSEE agrees that it will use the PROGRAM and any modifications, improvements, or derivatives of PROGRAM that LICENSEE may create (collectively, 
-%       "IMPROVEMENTS") solely for academic, non-commercial purposes and that any copy of PROGRAM or derivatives thereof shall be distributed only under the same 
-%       license as PROGRAM. The terms "academic, non-commercial", as used in this Agreement, mean academic or other scholarly research which (a) is not undertaken for 
-%       profit, or (b) is not intended to produce works, services, or data for commercial use, or (c) is neither conducted, nor funded, by a person or an entity engaged 
-%       in the commercial use, application or exploitation of works similar to the PROGRAM.
-% 5.	LICENSEE agrees that it shall make the following acknowledgement in any publication resulting from the use of the PROGRAM or any translation of the code into 
-%       another computing language:
-%       "Data processing was carried out using the cSAXS ptychography MATLAB package developed by the Science IT and the coherent X-ray scattering (CXS) groups, Paul 
-%       Scherrer Institut, Switzerland."
-%
-% Additionally, any publication using the package, or any translation of the code into another computing language should cite for difference map:
-% P. Thibault, M. Dierolf, A. Menzel, O. Bunk, C. David, F. Pfeiffer, High-resolution scanning X-ray diffraction microscopy, Science 321, 379–382 (2008). 
-%   (doi: 10.1126/science.1158573),
-% for maximum likelihood:
-% P. Thibault and M. Guizar-Sicairos, Maximum-likelihood refinement for coherent diffractive imaging, New J. Phys. 14, 063004 (2012). 
-%   (doi: 10.1088/1367-2630/14/6/063004),
-% for mixed coherent modes:
-% P. Thibault and A. Menzel, Reconstructing state mixtures from diffraction measurements, Nature 494, 68–71 (2013). (doi: 10.1038/nature11806),
-% and/or for multislice:
-% E. H. R. Tsai, I. Usov, A. Diaz, A. Menzel, and M. Guizar-Sicairos, X-ray ptychography with extended depth of field, Opt. Express 24, 29089–29108 (2016). 
-%   (doi: 10.1364/OE.24.029089).
-% 6.	Except for the above-mentioned acknowledgment, LICENSEE shall not use the PROGRAM title or the names or logos of LICENSOR, nor any adaptation thereof, nor the 
-%       names of any of its employees or laboratories, in any advertising, promotional or sales material without prior written consent obtained from LICENSOR in each case.
-% 7.	Ownership of all rights, including copyright in the PROGRAM and in any material associated therewith, shall at all times remain with LICENSOR, and LICENSEE 
-%       agrees to preserve same. LICENSEE agrees not to use any portion of the PROGRAM or of any IMPROVEMENTS in any machine-readable form outside the PROGRAM, nor to 
-%       make any copies except for its internal use, without prior written consent of LICENSOR. LICENSEE agrees to place the following copyright notice on any such copies: 
-%       © All rights reserved. PAUL SCHERRER INSTITUT, Switzerland, Laboratory for Macromolecules and Bioimaging, 2017. 
-% 8.	The LICENSE shall not be construed to confer any rights upon LICENSEE by implication or otherwise except as specifically set forth herein.
-% 9.	DISCLAIMER: LICENSEE shall be aware that Phase Focus Limited of Sheffield, UK has an international portfolio of patents and pending applications which relate 
-%       to ptychography and that the PROGRAM may be capable of being used in circumstances which may fall within the claims of one or more of the Phase Focus patents, 
-%       in particular of patent with international application number PCT/GB2005/001464. The LICENSOR explicitly declares not to indemnify the users of the software 
-%       in case Phase Focus or any other third party will open a legal action against the LICENSEE due to the use of the program.
-% 10.	This Agreement shall be governed by the material laws of Switzerland and any dispute arising out of this Agreement or use of the PROGRAM shall be brought before 
-%       the courts of Zürich, Switzerland. 
-
-
 function [ p ] = matlab_pos( p )
 
 for ii = 1:p.numscans
@@ -140,7 +85,7 @@ for ii = 1:p.numscans
                 end
             end
             
-        case 'custom'
+        case 'custom' %for PSI's data
             fn_splt = strsplit(p.scan.custom_positions_source,'.');
             if length(fn_splt)>1
                 % file already has an extension
@@ -168,6 +113,27 @@ for ii = 1:p.numscans
                 end
             end
             
+        case 'custom_GPU' %added by YJ for customized GPU engines' output
+            if ~isempty(p.scan.custom_positions_source) %guess the position file name from base path
+                pos_file = p.scan.custom_positions_source;
+            else
+            	error('Position file is not given');
+            end
+            
+            try
+                r_output = load(pos_file,'outputs');
+                r_p = load(pos_file,'p');
+            	ppX = r_output.outputs.probe_positions(:,1)*r_p.p.dx_spec(1);
+                ppY = r_output.outputs.probe_positions(:,2)*r_p.p.dx_spec(2);
+                ppX = ppX(:);
+                ppY = ppY(:);
+                positions_real = zeros(length(ppX),2); 
+
+                positions_real(:,1) = -ppY;
+                positions_real(:,2) = -ppX;                
+            catch
+                error('Failed to load positions from %s', pos_file);
+            end
         otherwise
             error('Unknown scan type %s.', p.scan.type);
     end

--- a/ptycho/ptycho_electron_nature_comm.m
+++ b/ptycho/ptycho_electron_nature_comm.m
@@ -90,8 +90,6 @@ p.   prepare.auto_center_data = false;                      % if matlab data pre
 
 % Scan positions
 p.   src_positions = 'matlab_pos';                           % 'spec', 'orchestra', 'load_from_file', 'matlab_pos' (scan params are defined below) or add new position loaders to +scan/+positions/
-%p.   src_positions = 'hdf5_pos_cu';                           % 'spec', 'orchestra', 'load_from_file', 'matlab_pos' (scan params are defined below) or add new position loaders to +scan/+positions/
-
 p.   positions_file = [''];    %Filename pattern for position files, Example: ['../../specES1/scan_positions/scan_%05d.dat']; (the scan number will be automatically filled in)
 
 p.   spec.motor.fine_motors = {};                           % Y and X motor name for positions, leave empty for defaults

--- a/ptycho/ptycho_electron_simulation_template.m
+++ b/ptycho/ptycho_electron_simulation_template.m
@@ -81,7 +81,7 @@ p.   prepare.prepare_data_function = '';                    % (used only if data
 p.   prepare.auto_center_data = false;                      % if matlab data preparator is used, try to automatically center the diffraction pattern to keep center of mass in center of diffraction
 
 % Scan positions
-p.   src_positions = 'hdf5_pos_aps';                           % 'spec', 'orchestra', 'load_from_file', 'matlab_pos' (scan params are defined below) or add new position loaders to +scan/+positions/
+p.   src_positions = 'hdf5_pos';                           % 'spec', 'orchestra', 'load_from_file', 'matlab_pos' (scan params are defined below) or add new position loaders to +scan/+positions/
 p.   positions_file = [''];    %Filename pattern for position files, Example: ['../../specES1/scan_positions/scan_%05d.dat']; (the scan number will be automatically filled in)
 
 p.   spec.motor.fine_motors = {};                           % Y and X motor name for positions, leave empty for defaults
@@ -89,8 +89,8 @@ p.   spec.motor.fine_motors_scale = [];                     % ptycho expects rea
 p.   spec.motor.coarse_motors = {};                         % Coarse sample position for shared object, use {X-motor, Y-motor} 
 p.   spec.motor.coarse_motors_scale = [];                   % Scale of the coarse motors (to scale the provided values to meters)
 
-% scan parameters for option src_positions = 'matlab_pos';
-p.   scan.type = 'custom';                                  % {'round', 'raster', 'round_roi', 'custom'}
+% scan parameters for option src_positions = 'matlab_pos' or 'hdf5_pos';
+p.   scan.type = 'default';                                  % {'round', 'raster', 'round_roi', 'custom'}
 p.   scan.roi_label = roi_label;                            % For APS data
 p.   scan.format = scan_string_format;                      % For APS data format for scan directory generation
 %%% PSI %%% 


### PR DESCRIPTION
Makes some changes to scan position readers:
1. hdf5_pos_aps.m and hdf5_pos_cu.m will no longer be used. They are replaced by the combined function: hdf5_pos.m.
I'll keep hdf5_pos_aps.m for now for backward compatibility.
2. In hdf5_pos.m, the 'custom' scan type is renamed to 'default'. 'pre_recon' is renamed to 'custom'. This is more consistent with PSI's convention.
3. In matlab_pos.m, add a new scan type "custom_GPU", which loads position from Matlab files saved by the GPU engines.
4. Update the example scripts.
 