### PR TITLE
adjust probe size for up-sampled diffraction pattern

### DIFF
--- a/ptycho/+core/ptycho_model_probe.m
+++ b/ptycho/+core/ptycho_model_probe.m
@@ -6,7 +6,11 @@ import io.*
 
 % Define often-used variables
 lambda = p.lambda;
-asize = p.asize; % Diffr. patt. array size   
+asize = p.asize; % Diffr. patt. array size  
+% added by YJ for up-sampled diffraction patterns.
+if p.detector.upsampling >0
+	asize = asize*2^p.detector.upsampling;
+end
 dx_spec = p.dx_spec;
 a2 = prod(asize);
 


### PR DESCRIPTION
Automatically just probe size if diffraction patterns are upsampled during initialization. This can be useful if the input probe is reconstructed from up-sampled data.

Example script: ptycho_velo_21c1_comm_upsampled2.m