### PR TITLE
add diagnosis scripts for scan positions and probe variation analysis

### DIFF
--- a/ptycho/diagnosis/view_probe_variation.m
+++ b/ptycho/diagnosis/view_probe_variation.m
@@ -1,0 +1,109 @@
+%view_probe_variation.m
+close all
+clear
+addpath(strcat(pwd,'/utils/'))
+
+% load a .mat reconstruction file w. probe variation correction 
+%% calculate probes at each scan positions
+Np_p = [size(probe,1),size(probe,2)];
+probes = reshape(probe(:,:,1,:),prod(Np_p),[]);
+probes = reshape(probes * outputs.probe_evolution', Np_p(1), Np_p(2), []);
+
+%% generate a movie to show scan positions and probes
+disp('Generating movie frames')
+figure1 = figure('Color',[1 1 1],'OuterPosition',[100 100 1800 600]);
+clear M
+object_roi = object(p.object_ROI{:},:);
+N_sample = 1;
+N_frames = 120;
+%N_frames = floor(size(outputs.probe_positions(:,1),1)/N_sample);
+%scale = p.dx_spec*1e6; % x-ray 
+%unit_label = '\mum'; % x-ray 
+
+scale = p.dx_spec; % electron
+unit_label = 'A';
+for i=1:N_frames
+    clf()
+    subplot(1,2,1)
+    aobject = angle(object);
+    range = sp_quantile(angle(object_roi), [1e-3, 1-1e-3],10);
+    aobject = (aobject  - range(1)) / (range(2) - range(1));
+    Np_o = size(object);
+    grids = {(-ceil(Np_o(2)/2):ceil(Np_o(2)/2)-1)*scale(2), ...
+             (-ceil(Np_o(1)/2):ceil(Np_o(1)/2)-1)*scale(1)}; 
+    imagesc(grids{:}, aobject, [-2, 1]); % reduce contrast 
+    colormap bone 
+    axis xy
+    hold on 
+    pos = outputs.probe_positions;
+    pos_0 = outputs.probe_positions_0;
+
+    pos_scales = pos .* scale([2,1]); 
+    pos_scales_0 = pos_0 .* scale([2,1]); 
+    scatter( pos_scales(:,1),  pos_scales(:,2),'.r')
+    scatter( pos_scales_0(:,1),  pos_scales_0(:,2),10, '.','MarkerEdgeColor','b')
+
+    scatter( pos_scales(1+(i-1)*N_sample,1),  pos_scales(1+(i-1)*N_sample,2),50,'ok','filled')
+    axis equal xy tight 
+    range =  [min(pos_scales(:,1)), max(pos_scales(:,1)), min(pos_scales(:,2)), max(pos_scales(:,2))];
+    axis(range)
+    title(['\fontsize{12}{\color{blue}initial positions, '...
+'\color{red}refined positions, \color{black}current probe position}'])
+    ylabel(['Position [', unit_label, ']'])
+
+    subplot(1,2,2)
+
+    imagesc_hsv(probes(:,:,1+(i-1)*N_sample),'stabilize_phase',false)
+    axis off
+    title('primary probe mode')
+    drawnow;
+    M(i) = getframe(gcf);
+end
+disp('Done')
+
+%% save movie
+disp('Saving movie...')
+movieName = strcat('probes_selected.avi');
+v= VideoWriter(movieName);
+
+v.FrameRate= 5;
+open(v)
+writeVideo(v,M);
+close(v)
+disp('Done')
+
+%% plot OPR modes (U)
+N_vp = size(probe,4)-1;
+figure
+ax(1)=subplot(2,1+N_vp,1);
+imagesc_hsv(probe(:,:,1,1),'stabilize_phase',false)
+axis xy off
+title('Constant mode')
+
+for ii = 2:N_vp+1
+    ax(ii)=subplot(2,1+N_vp,ii);
+    imagesc_hsv(probe(:,:,1,ii),'stabilize_phase',false)
+    axis xy off 
+    title(sprintf('Variable mode %i', ii-1))
+end
+
+for ii = 1:N_vp+1
+    ax(ii+1+N_vp)=subplot(2,1+N_vp,1+N_vp+ii);
+    scatter(outputs.probe_positions(:,1)*p.dx_spec(1),outputs.probe_positions(:,2)*p.dx_spec(1),[],outputs.probe_evolution(:,ii));
+    
+    %axis xy off 
+    title(strcat('Average weights:', num2str(mean(outputs.probe_evolution(:,ii)))))
+    %title(strcat(num2str(mean(outputs.probe_evolution(:,ii)))))
+end
+
+%% save probes as a tiff stack
+Np_p = [size(probe,1),size(probe,2)];
+probes = reshape(probe(:,:,1,:),prod(Np_p),[]);
+probes = reshape(probes * outputs.probe_evolution', Np_p(1), Np_p(2), []);
+resampleFactor = round(size(probes,3)/200); %only save ~100 images
+probes_temp = probes(:,:,1:resampleFactor:end);
+saveName = strcat(reconDir,'probes_Niter',num2str(Niter),'.tiff');
+imwrite(convert_to_rgb(probes_temp(:,:,1)), saveName,'tiff')
+for i=2:size(probes_temp,3)
+    imwrite(convert_to_rgb(probes_temp(:,:,i)), saveName,'tiff', 'WriteMode','append')
+end    

--- a/ptycho/diagnosis/view_scan_positions.m
+++ b/ptycho/diagnosis/view_scan_positions.m
@@ -1,0 +1,81 @@
+close all
+addpath(fullfile(pwd,'utils'))
+%%
+figure1 = figure('Color',[1 1 1],'OuterPosition',[100 100 1800 600]);
+%set(gcf,'Outerposition',[100 100 1800 600])
+clf()
+%set(gca,'color','white')
+scale = p.dx_spec; 
+%object_roi = object(p.object_ROI{:},:);
+aobject = angle(object);
+range = sp_quantile(angle(object_roi), [1e-3, 1-1e-3],10);
+aobject = (aobject  - range(1)) / (range(2) - range(1));
+Np_o = size(object);
+grids = {(-ceil(Np_o(2)/2):ceil(Np_o(2)/2)-1)*scale(2), ...
+         (-ceil(Np_o(1)/2):ceil(Np_o(1)/2)-1)*scale(1)}; 
+imagesc(grids{:}, aobject, [-2, 1]); % reduce contrast 
+colormap bone 
+axis xy
+hold on 
+pos = outputs.probe_positions;
+pos_0 = outputs.probe_positions_0;
+
+%pos = pos + Np_o([2,1])/2;
+%pos_scales = (pos-Np_o([2,1])/2) .* scale([2,1]); 
+pos_scales = pos .* scale([2,1]); 
+pos_scales_0 = pos_0 .* scale([2,1]); 
+%mean_err = mean(std(pos_err)); 
+%range = max(pos) - min(pos); 
+%up = 0.02 * min(range) / mean_err; 
+%rounding_order = 10^floor(log10(up)); 
+%up = ceil(up / rounding_order)*rounding_order;
+scatter( pos_scales(:,1),  pos_scales(:,2),'.r')
+scatter( pos_scales_0(:,1),  pos_scales_0(:,2),10, '.','MarkerEdgeColor','b')
+
+%hold off 
+axis equal xy tight 
+range =  [min(pos_scales(:,1)), max(pos_scales(:,1)), min(pos_scales(:,2)), max(pos_scales(:,2))];
+axis(range)
+title(['\fontsize{16}{\color{blue}initial positions, '...
+'\color{red}refined positions}'])
+%title('Initial positions: blue. Refined positions: red. Current probe position: Black')
+%ylabel('Position [\mum]') %for x-ray
+%xlabel('Position [\mum]')
+ylabel('Position [A]') %for electron
+xlabel('Position [A]')
+
+%%
+close all
+figure
+subplot(2,2,1)
+plot(outputs.relative_pixel_scale,'.','MarkerSize',4)
+axis tight 
+ylabel('Relative pixel scaling correction [-]')
+xlabel('Iteration')
+title('Scales')
+hold off 
+grid on 
+
+subplot(2,2,2)
+plot(outputs.asymmetry*100,'.','MarkerSize',4)
+axis tight 
+ylabel('Asymmetry [%]')
+xlabel('Iteration')
+title('Asymmetry')
+grid on 
+
+subplot(2,2,3)
+plot(outputs.rotation,'.','MarkerSize',4)
+axis tight 
+ylabel('Rotation  [deg]')
+xlabel('Iteration')
+title('Rotation')
+grid on 
+
+subplot(2,2,4)
+plot(outputs.shear,'.','MarkerSize',4)
+axis tight 
+ylabel('Shear  [deg]')
+xlabel('Iteration')
+title('Shear')
+grid on 


### PR DESCRIPTION
Add two more analysis scripts for viewing scan positions and probe variation correction:

view_scan_positions.m
1. Shows initial and refined scan positions
2. Show evolution of geometry model parameters

view_probe_variation.m
1. Calculate probe at each scan positions
2. Make a movie showing probes
3. Show OPR modes and weights at each scan position
