### PR TITLE
support unequal dk_x/y

### DIFF
--- a/ptycho/+core/initialize_ptycho.m
+++ b/ptycho/+core/initialize_ptycho.m
@@ -88,9 +88,9 @@ else
     % modified by YJ for electron pty
     if isfield(p,'beam_source') && strcmp(p.beam_source, 'electron')
         if isfield(p,'dk')  %A^-1/pix 
-            p.dx_spec = 1./p.asize/p.dk; %angstrom
+            p.dx_spec = 1./p.asize./p.dk; %angstrom
         elseif isfield(p,'d_alpha') % mrad/pix
-            p.dx_spec = 1./p.asize/(p.d_alpha/1e3/p.lambda); %angstrom
+            p.dx_spec = 1./p.asize./(p.d_alpha/1e3/p.lambda); %angstrom
         else
             error('dk or d_alpha are not speficied!')
         end


### PR DESCRIPTION
change dx, dk, dalpha in +core/initialize_ptycho.m to support unequal dk along x/y direction. 
dx_x/y will be unequal too. The final phase image will also show unequal sampling, be careful when measuring distance!
