### PR TITLE
increase the verbose level for p.detector.data_prefix

### DIFF
--- a/ptycho/+core/initial_checks.m
+++ b/ptycho/+core/initial_checks.m
@@ -105,7 +105,7 @@ if isempty(p.detector.data_prefix)
         % default setting for cSAXS beamline
         p.detector.data_prefix = [eaccount '_1_'];
     else
-        verbose(0,'p.detector.data_prefix is not defined')
+        verbose(3,'p.detector.data_prefix is not defined')
     end
 end
 


### PR DESCRIPTION
Increase the verbose level for the "p.detector.data_prefix" variable to 3 so that its warning message is not printed out for regular reconstructions. The variable is never used for the APS data or electron ptychography.