### PR TITLE
further simplify the ePIE code

### DIFF
--- a/ptycho/python/ptycho_recon/pie_mixed_states.py
+++ b/ptycho/python/ptycho_recon/pie_mixed_states.py
@@ -39,7 +39,7 @@ def reconPIE_mixed_state(dp, paraDict):
     else:
         probes = np.zeros((N_probe, N_roi, N_roi), dtype=np.complex128)
         if paraDict['normalizeInitialProbe']:
-            print('normalize initial probe intensity to match CBED')
+            #print('normalize initial probe intensity to match CBED')
             probe = paraDict['probe0'] * sqrt(np.sum(dp_avg) / np.sum(abs(paraDict['probe0'])**2) / N_tot)
         else:
             probe = paraDict['probe0']
@@ -73,7 +73,6 @@ def reconPIE_mixed_state(dp, paraDict):
     resultDir['probes'] = probes
     resultDir['probe0'] = paraDict['probe0'].copy()
     if 'probes0' in paraDict: resultDir['probes0'] = paraDict['probes0'].copy()
-    resultDir['rotationAngle'] = paraDict['rotationAngle']
     resultDir['dx_x'] = 1.0/(paraDict['dk_x']*N_roi); 
     resultDir['dx_y'] = 1.0/(paraDict['dk_y']*N_roi);
     resultDir['dk_x'] = paraDict['dk_x']; resultDir['dk_y'] = paraDict['dk_y']
@@ -114,14 +113,7 @@ def reconPIE_mixed_state(dp, paraDict):
             
             probes_temp = gramschmidt(probes.reshape(N_probe, N_roi*N_roi))
             probes[:,:,:] = probes_temp.reshape(N_probe, N_roi, N_roi)
-            '''
-            #sort probes based on power
-            power = sum(abs(probes)**2, axis=(1,2))
-            power_ind = argsort(-power)
-            probes[:,:,:] = probes[power_ind,:,:]
-            
-            probes[:,:,:] = auxiFunc.orthoProbe(probes)
-            '''
+           
         update_order = random.permutation(paraDict['N_scan']) #random order
  
         for i in update_order:
@@ -155,30 +147,15 @@ def reconPIE_mixed_state(dp, paraDict):
                     probe_update = auxiFunc.calculateUpdate(O_old, delta_psi[p,:,:], 'p')
                     probes_shifted[p,:,:] += probe_update
                     probes[p,:,:] = auxiFunc.shiftProb(probes_shifted[p,:,:], i, 'toOrigin', checkFilter=True)
-                    #probes_shifted[p,:,:] += beta/O_tot_max * conj(O_old) * delta_psi[p,:,:,]
-                    
-                    #r[:,:] =  probes_shifted[p,:,:]; fft_forward.update_arrays(r,f); fft_forward.execute()
-                    #f = f*exp(2*pi*1j*px_f[i]*kX)*exp(2*pi*1j*py_f[i]*kY)
-                    #if paraDict.has_key('filter_f_probe'): f = f * paraDict['filter_f_probe']
-                    #fft_inverse.update_arrays(f,r); fft_inverse.execute();
-                    #probes[p,:,:] = r / N_tot
-                    #if paraDict.has_key('filter_r_probe'): probes[p,:,:] = probes[p,:,:] * paraDict['filter_r_probe']
-            #if k >= paraDict['Niter_position_correction']:
+
             if k>=paraDict['Niter_update_position']:
                 auxiFunc.gradPositionCorrection(probe_old[0,:,:], O_old, i, delta_psi[0,:,:])
 
         ############################### orthogonalise probe #######################################
         if k >= paraDict['Niter_update_states']:
-            
             probes_temp = gramschmidt(probes.reshape(N_probe, N_roi*N_roi))
             probes[:,:,:] = probes_temp.reshape(N_probe, N_roi, N_roi)
-            '''
-            #sort probes based on power
-            power = sum(abs(probes)**2, axis=(1,2))
-            power_ind = argsort(-power)
-            probes[:,:,:] = probes[power_ind,:,:]
-            '''
-            #probes[:,:,:] = auxiFunc.orthoProbe(probes)
+           
         ############################### calcuate data error #######################################
         s[k] = np.sum(dp_error)/dp_tot
         dp_error_old = dp_error.copy()

--- a/ptycho/python/ptycho_recon/utility_function.py
+++ b/ptycho/python/ptycho_recon/utility_function.py
@@ -336,7 +336,7 @@ def resample_scan(input, windowSize, scanStepSize_x, scanStepSize_y, directory =
 
 ##############################################################################################
 def transpose_cbed(input, directory = ""):
-    print("transpose cbed patterns...")
+    print("transpose cbed patterns")
     output = zeros((input.shape[1],input.shape[0],input.shape[2],input.shape[3]))
 
     for i in range(input.shape[2]):
@@ -399,7 +399,7 @@ def normalize_cbed(input, dk, directory = ""):
     
 ##############################################################################################
 def background_removal(input, bg_level, directory = ""):
-    print("removing background... level=", bg_level)
+    print("removing background: threshold=", bg_level)
     output = input.copy()
     output[output<=bg_level] = 0
     directory = directory + "_bgRemoval"+str(bg_level)
@@ -407,7 +407,7 @@ def background_removal(input, bg_level, directory = ""):
 
 ##############################################################################################
 def background_subtraction(input, bg_level, directory = ""):
-    print("subtracting background... level=", bg_level)
+    print("subtracting background: threshold=", bg_level)
 
     output = input - bg_level
     output[output<0] = 0
@@ -417,7 +417,7 @@ def background_subtraction(input, bg_level, directory = ""):
 
 ##############################################################################################
 def calculate_scan_positions(N_scan_x, N_scan_y, scanStepSize_x, scanStepSize_y, rot_angle_d = 0, directory = "", randomOffset = 0, ppX = 0, ppY = 0):
-    print("calculating scan positions...")
+    print("calculate scan positions")
     print("N_scan_x =", N_scan_x, "scanStepSize_x =", scanStepSize_x)
     print("N_scan_y =", N_scan_y, "scanStepSize_y =", scanStepSize_y)
     print("rot_angle =", rot_angle_d)

--- a/ptycho/python/recon_example.py
+++ b/ptycho/python/recon_example.py
@@ -39,8 +39,10 @@ voltage = squeeze(data['voltage']) #kev
 alpha_max = squeeze(data['alpha_max']) #mrad
 df = squeeze(data['df'])
 cs = squeeze(data['cs']) #angstrom
-scanStepSize_x = squeeze(data['scanStepSize_x'])
-scanStepSize_y = squeeze(data['scanStepSize_y'])
+#scanStepSize_x = squeeze(data['scanStepSize_x']) #angstrom
+#scanStepSize_y = squeeze(data['scanStepSize_y'])
+scanStepSize_x = 0.21 #angstrom
+scanStepSize_y = 0.21
 
 dk = squeeze(data['dk'])
 
@@ -75,7 +77,7 @@ Ny_max = max([abs(round(np.min(ppY)/dx)-floor(N_roi/2.0)), abs(round(np.max(ppY)
 Nx_max = max([abs(round(np.min(ppX)/dx)-floor(N_roi/2.0)), abs(round(np.max(ppX)/dx)+ceil(N_roi/2.0))])*2+1
 N_image = int(max([Ny_max,Nx_max]))+20
 print("Image size:", N_image)
-
+'''
 ######### reshape dp and scan positions #########
 N_scan_y = dp.shape[2]
 N_scan_x = dp.shape[3]
@@ -89,44 +91,30 @@ for i in range(N_scan_y):
     for j in range(N_scan_x):
         index = i*N_scan_x + j
         dp_temp[index,:,:] = sqrt(dp[:,:,i,j])
-
+'''
 ########################################### reconstruction #####################################
 print('Reconstruction')
-reconObject = pty.ptycho(dp_temp, dk, probe_init, ppX, ppY)
-reconObject.paraDict['dk_y'] = dk
-reconObject.paraDict['dk_x'] = dk
+reconObject = pty.ptycho(dp, dk, probe_init, ppX, ppY)
 reconObject.paraDict['N_image'] = N_image
 reconObject.paraDict['N_roi'] = N_roi
-reconObject.paraDict['Niter'] = 200
+reconObject.paraDict['Niter'] = 50
 reconObject.paraDict['Niter_update_probe'] = 0
-reconObject.paraDict['Niter_save'] = 100
+reconObject.paraDict['Niter_save'] = 5
 
-reconObject.paraDict['beta'] = 1
-reconObject.paraDict['alpha'] = 0.1
-
-reconObject.paraDict['normalizeInitialProbe'] = False
-reconObject.paraDict['uniformInitialObject'] = True
 reconObject.paraDict['rotationAngle']  = rot_angle_d
 
 reconObject.paraDict['printID'] = 'MoS2'
 
 ############## position correction ##############
-reconObject.paraDict['Niter_update_position'] = 100
+reconObject.paraDict['Niter_update_position'] = 30
 
 ############## mixed-states recon ##############
 reconObject.paraDict['N_probe'] = 2
-reconObject.paraDict['N_object'] = 1
-reconObject.paraDict['Niter_update_states'] = 50
+reconObject.paraDict['Niter_update_states'] = 10
 
-result_dir = currentdir + "/mos2" + result_dir_extra
+result_dir = currentdir + "/mos2"
 result_dir_extra = reconObject.initialize(result_dir)
 
-############## load existing probe ##############
-#reconObject.paraDict['probes0'] = probes0 #mixed states opr
-#reconObject.paraDict['probe0_info'] = probe_dir + '/' + probe_name
-
-print(result_dir_extra)
-print(reconObject.paraDict['saveName'])
 start_time = time.time()
 reconObject.recon() #start reconstruction
 total_time = time.time() - start_time


### PR DESCRIPTION
Further simplify the ePIE code added in #68  
1. Delete more unused code.
2. Many input parameters are now hidden from the users and are initialized in ptycho.m.
3. Shorten the output directory and file name.
