### PR TITLE
add an option that only keeps the averaged layer during multi-slice ptychography initialization

### DIFF
--- a/ptycho/+engines/+GPU_MS/+initialize/get_defaults.m
+++ b/ptycho/+engines/+GPU_MS/+initialize/get_defaults.m
@@ -91,6 +91,7 @@ function [param] = get_defaults
     param.init_layer_preprocess = '';   % Added by YJ. Specify how to pre-process initial layers
                                        % '' or 'all' (default): use all layers (do nothing)
                                        % 'avg': average all layers 
+                                       % 'avg1': keep one averaged layer 
                                        % 'interp': interpolate layers using spline method. Need to specify desired depths in init_layer_interp
     param.init_layer_interp = [];     % Specify desired depths for interpolation. The depths of initial are [1:Nlayer_init]. If empty (default), no interpolation                    
     param.init_layer_append_mode = '';  % Added by YJ. Specify how to initialize extra layers

--- a/ptycho/+engines/+GPU_MS/+initialize/init_solver.m
+++ b/ptycho/+engines/+GPU_MS/+initialize/init_solver.m
@@ -249,7 +249,7 @@ function [self, cache] = init_solver(self,par)
         end
         
         distance = self.z_distance(min(end,i));
-        
+
         if ~isinf(distance)
             verbose(2, 'Layer %i distance %g um  ', i, distance*1e6 )
         end
@@ -456,7 +456,16 @@ function [self, cache] = init_solver(self,par)
                     self.object{ll,jj} = obj_avg;
                 end
             end
-        case 'interp' % interpolate layers 
+        case 'avg1' % only use the averaged layer
+            verbose(0,'Average initial layers and only keep one')
+            object_temp = cell(size(self.object,1),1);
+            for ll = 1:par.Nscans
+                obj_avg = prod(cat(3,self.object{ll,:}),3); 
+                obj_avg = abs(obj_avg).*exp(1i*phase_unwrap(angle(obj_avg))/size(self.object,2));
+                object_temp{ll,1} = obj_avg;
+            end
+            self.object = object_temp;
+        case 'interp' % interpolate layers
             if ~isempty(par.init_layer_interp)
                 verbose(0,'Interpolate %d initial layers to %d layers', size(self.object,2), length(par.init_layer_interp))
                 for ll = 1:par.Nscans
@@ -584,7 +593,6 @@ function [self, cache] = init_solver(self,par)
     self.noise = Noise; 
     self.mask = Mask; 
     self.background = reshape(Background,1,1,[]);        
-
     
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     %%%%%%%%%%% PRECALCULATE USEFUL VALUES %%%%%%%


### PR DESCRIPTION
Add a new option in eng.init_layer_preprocess = 'avg1'. This averages all input layers and then keeps one for further processing. The implementation is not elegant but good enough for now since the option is not used frequently. 