### PR TITLE
use the same object layer for position correction and weight calculation

### DIFF
--- a/ptycho/+engines/+GPU_MS/+initialize/check_inputs.m
+++ b/ptycho/+engines/+GPU_MS/+initialize/check_inputs.m
@@ -109,7 +109,7 @@ end
 %%%%%% checks for the multilayer method  %%%%%%%%%%%%%%%%
 %Note: self.z_distance is first initialized in load_from_p.m, where a
 %vacuum layer is appended: self.z_distance = [p.delta_z, inf] for far-field 
-par.Nlayers = length(self.z_distance); 
+par.Nlayers = length(self.z_distance);
 if par.Nlayers > 1 && isinf(self.z_distance(end)) 
     % Added by ZC: exclude the last vacuum (inf) layer for multisluce
     par.Nlayers = par.Nlayers - 1;
@@ -126,6 +126,10 @@ end
 % end
 if par.Nlayers > 1 && par.Nscans > 1
 	error('Multilayer extension is not supported with multiple scans')
+end
+% Added by ZC. allow user to specify the layer used for position correction
+if ~isfield(par,'layer4pos') || isempty(par.layer4pos) 
+    par.layer4pos = ceil(par.Nlayers/2);
 end
 
 %%%%%%%%%%  fast scanning %%%%%%%%%%%%%%%%%%%%%%%%%

--- a/ptycho/+engines/+GPU_MS/+shared/find_geom_correction.m
+++ b/ptycho/+engines/+GPU_MS/+shared/find_geom_correction.m
@@ -1,28 +1,29 @@
 % FIND_GEOM_CORRECTION use current probe positions estimates to update geometry model and
 % improve the  new probe positions 
 %
-% [self] = find_geom_correction(self,cache, par, iter,best_mode_id)
+% [self] = find_geom_correction(self,cache, par, iter, best_mode_id, update_position_weight)
 % 
 %
 % ** self      structure containing inputs: e.g. current reconstruction results, data, mask, positions, pixel size, ..
 % ** cache     structure with precalculated values to avoid unnecessary overhead
 % ** par       structure containing parameters for the engines 
 % ** iter      current iteration 
-% ** best_mode_id   strongest mode id
+% ** best_mode_id             strongest mode id
+% ** update_position_weight   update_position_weight
 %
 % returns:
 % ++ self        self-like structure with final reconstruction
 %
 %
-function [self] = find_geom_correction(self,cache, par, iter,best_mode_id, update_position_weight)
+function [self] = find_geom_correction(self,cache, par, iter, best_mode_id, update_position_weight)
 
     import engines.GPU_MS.GPU_wrapper.*
     import engines.GPU_MS.shared.*
     import utils.*
     import math.*
-    
+
     mode = self.modes{best_mode_id};
-   
+
     %% constrain the detector rotation 
      
     % store only the single update per scan 
@@ -60,8 +61,7 @@ function [self] = find_geom_correction(self,cache, par, iter,best_mode_id, updat
         total_variation = zeros(self.Npos,2, 'single'); 
         
         for ii = 1:par.Nscans
-            best_layer = par.Nlayers;
-            o_tmp =  self.object{min(end,ii), best_layer}; 
+            o_tmp =  self.object{min(end,ii), par.layer4pos}; 
             o_tmp = o_tmp ./ max2(abs(o_tmp(cache.object_ROI{:})));
             % keep it more memory effecient (important for GPU !! )
             Npos = length(self.reconstruct_ind{ii});

--- a/ptycho/+engines/+GPU_MS/LSQML.m
+++ b/ptycho/+engines/+GPU_MS/LSQML.m
@@ -277,10 +277,7 @@ function [self, cache, fourier_error] =  LSQML(self,par,cache,fourier_error,iter
                 if object_reconstruct && is_method(par, 'MLs') 
                     self.object = update_object(self, self.object, object_upd_sum, layer_ids{jj}(layer), llo, {g_ind}, scan_ids(jj), par, cache, beta_object);
                 end
-                % Added by ZC. allow user to specify layer for position corr.
-                if ~isfield(par,'layer4pos') || isempty(par.layer4pos) 
-                    par.layer4pos = ceil(par.Nlayers/2);
-                end
+                
                 if  ll == 1  &&  layer == par.layer4pos %layer == ceil(par.Nlayers/2)  % assume that sample in center is best constrained . Changed to variable layer by Zhen Chen
                     %%%%%%%%%%%%% update other parameters of the ptychography model
                     if  iter >= par.probe_position_search || iter >= par.detector_rotation_search || iter >= par.detector_scale_search


### PR DESCRIPTION
There was a bug in the "find_geom_correction" function that always uses the last object layer to calculate the weights for position regularization, while the layer used for position correction can be specified by the user. This may lead to inaccurate position correction especially when layer structures vary a lot.

This PR fixes the bug by using par.layer4pos for both position correction and position weight calculation.