### PR TITLE
save object layers in a single tiff stack

### DIFF
--- a/ptycho/+engines/+GPU/+initialize/get_defaults.m
+++ b/ptycho/+engines/+GPU/+initialize/get_defaults.m
@@ -118,5 +118,5 @@ function [param] = get_defaults
     
     % I/O
     param.save_init_probe = false;       % Added by YJ. If true, save initial probe function in the .mat output file. Default is false.
-	param.save_images = {'obj_ph','probe'}; % Added by YJ. Save intermediate results as tiff images. Options: {'obj_ph','obj_ph_sum','probe_mag','probe'}
+	param.save_images = {'obj_ph','probe'}; % Added by YJ. Save intermediate results as tiff images. Options: {'obj_ph','obj_ph_sum','obj_ph_stack','probe_mag','probe'}
 end

--- a/ptycho/+engines/+GPU/ptycho_solver.m
+++ b/ptycho/+engines/+GPU/ptycho_solver.m
@@ -620,34 +620,44 @@ while iter <= par.number_iterations %modified by YJ: use while loop for time-res
         save(strcat(par.fout,'Niter',num2str(iter),'.mat'),'outputs','p','probe','object');
         
         %% save object phase
-        if ismember('obj_ph', par.save_images) || ismember('obj_ph_sum', par.save_images)
+        if any(ismember({'obj_ph','obj_ph_sum','obj_ph_stack'}, par.save_images))
             object_temp = Ggather(self.object{1});
-            object_roi_temp = object_temp(cache.object_ROI{:});        
+            object_roi_temp = object_temp(cache.object_ROI{:},:);
+            N_obj_roi = size(object_roi_temp);
+            O_phase_roi = zeros(N_obj_roi(1), N_obj_roi(2), par.Nlayers);
+            for ll=1:par.Nlayers
+                object_temp = Ggather(self.object{ll});
+                O_phase_roi(:,:,ll) = phase_unwrap(angle(object_temp(cache.object_ROI{:})));
+            end
             if ismember('obj_ph_sum', par.save_images)
-                O_phase_roi = phase_unwrap(angle(prod(object_roi_temp,3)));
+                O_phase_roi_sum = sum(O_phase_roi,3);
                 saveName = strcat('obj_phase_roi_sum_Niter',num2str(iter),'.tiff');
                 saveDir = strcat(par.fout,'/obj_phase_roi_sum/');
                 if ~exist(saveDir, 'dir'); mkdir(saveDir); end
-                save_tiff_image(O_phase_roi,strcat(saveDir,saveName));
+                save_tiff_image(O_phase_roi_sum,strcat(saveDir,saveName));
             end
             if ismember('obj_ph', par.save_images)
-                O_phase_roi = zeros(size(object_roi_temp,1), size(object_roi_temp,2)*par.Nlayers);
+                O_phase_roi2 = zeros(N_obj_roi(1), N_obj_roi(2)*par.Nlayers);
                 for ll=1:par.Nlayers
-                    object_temp = Ggather(self.object{ll});
-                    object_roi = object_temp(cache.object_ROI{:});
-                    x_lb = (ll-1)*size(object_roi,2)+1;
-                    x_ub = ll*size(object_roi,2);
-                    O_phase_roi(:,x_lb:x_ub) = phase_unwrap(angle(object_roi));
+                    x_lb = (ll-1)*N_obj_roi(2)+1;
+                    x_ub = ll*N_obj_roi(2);
+                    O_phase_roi2(:,x_lb:x_ub) = O_phase_roi(:,:,ll);
                 end
                 saveName = strcat('obj_phase_roi_Niter',num2str(iter),'.tiff');
                 saveDir = strcat(par.fout,'/obj_phase_roi/');
                 if ~exist(saveDir, 'dir'); mkdir(saveDir); end
-                save_tiff_image(O_phase_roi,strcat(saveDir,saveName));
+                save_tiff_image(O_phase_roi2,strcat(saveDir,saveName));
+            end
+            if ismember('obj_ph_stack', par.save_images)
+                saveName = strcat('obj_phase_roi_Niter',num2str(iter),'.tiff');
+                saveDir = strcat(par.fout,'/obj_phase_roi_stack/');
+                if ~exist(saveDir, 'dir'); mkdir(saveDir); end
+                imExportTiff(O_phase_roi,strcat(saveDir,saveName),'XY');
             end
         end
         
         %% save probe
-        if ismember('probe_mag', par.save_images) || ismember('probe', par.save_images)
+        if any(ismember({'probe_mag','probe'}, par.save_images))
             probe_temp = zeros(size(probe,1),size(probe,2)*par.probe_modes);
             for jj=1:par.probe_modes
                 x_lb = (jj-1)*size(probe,2)+1;

--- a/ptycho/+engines/+GPU_MS/+initialize/get_defaults.m
+++ b/ptycho/+engines/+GPU_MS/+initialize/get_defaults.m
@@ -120,5 +120,5 @@ function [param] = get_defaults
 
     % I/O
     param.save_init_probe = false;       % Added by YJ. If true, save initial probe function in the .mat output file. Default is false.
-    param.save_images = {'obj_ph','obj_ph_sum','probe'}; % Added by YJ. Save intermediate results as tiff images. Options: {'obj_ph','obj_ph_sum','probe_mag','probe'}
+    param.save_images = {'obj_ph','obj_ph_sum','probe'}; % Added by YJ. Save intermediate results as tiff images. Options: {'obj_ph','obj_ph_sum','obj_ph_stack','probe_mag','probe'}
 end


### PR DESCRIPTION
Add an option in eng.save_images = {'obj_ph_stack'} that outputs object layers in a single tiff stack during multislice reconstruction. Also, phase unwrapping is now applied to each individual layer instead of the total object function.
These modifications are particularly useful for electron ptychography, which often has very phase change and needs a lot of (>20) layers.

