### PR TITLE
Disable RNG seed setter in the model probe function and the GPU engines

### DIFF
--- a/ptycho/+core/ptycho_model_probe.m
+++ b/ptycho/+core/ptycho_model_probe.m
@@ -108,7 +108,7 @@ if p.model_probe
                 w = w .*(1-fftshift(filt2d_pad(upsample*asize(1), round(r2_pix)+2, round(r2_pix-2), 'circ')));
             end
             if isfield(p.model,'probe_structured_illum_power') && p.model.probe_structured_illum_power
-                rng default
+                %rng default
                 r = utils.imgaussfilt2_fft(randn(upsample*p.asize),upsample*2); 
                 r = r / math.norm2(r); 
                 r = exp(1i*r*p.model.probe_structured_illum_power);

--- a/ptycho/+engines/+GPU/+initialize/get_defaults.m
+++ b/ptycho/+engines/+GPU/+initialize/get_defaults.m
@@ -110,8 +110,8 @@ function [param] = get_defaults
     param.rm_grid_artifact_window_size = [5,5];     % window size in the [horizontal, vertical] directions
     param.rm_grid_artifact_direction = 'xy';        % filter directions: 'x' (horizontal), 'y' (vertical), or 'xy' (default)
 
-    rng('default');
-    rng('shuffle');
+    %rng('default');
+    %rng('shuffle');
     
     % convergence check - stop reconstruction if fourier error is larger than the previous one by given (relative) threshold. 
     param.fourier_error_threshold = inf; % default: no convergence check.

--- a/ptycho/+engines/+GPU/+initialize/private/get_close_indices.m
+++ b/ptycho/+engines/+GPU/+initialize/private/get_close_indices.m
@@ -97,7 +97,7 @@ if Nsets == 1 && grouping >= self.Npos
     return
 end
 
-rng default
+%rng default
 
 for kk = 1:Nsets
     % take them sequentially but with random offset 
@@ -243,7 +243,7 @@ verbose(0,'=== Position clusters found in %i iterations in %3.2gs', iter, cluste
 verbose(0,'=== Position clusters refined in %i iterations in %3.2gs', iter, cluster_refinement_time)
 
 
-rng shuffle 
+%rng shuffle 
 
 if verbose()  > 1 && Ngroups_sizes > 1
     warning('Unequal group sizes, it may cause slower calculation')

--- a/ptycho/+engines/+GPU_MS/+initialize/get_defaults.m
+++ b/ptycho/+engines/+GPU_MS/+initialize/get_defaults.m
@@ -52,7 +52,6 @@ function [param] = get_defaults
     param.background_detection = false; 
     param.background_width = inf;
 
-    
     %% ADVANCED OPTIONS   
     
     param.object_regular =  [0, 0]; %  enforce smoothness !!!, use between [0-0.1 ]
@@ -112,8 +111,8 @@ function [param] = get_defaults
     % fly scans 
     param.flyscan_offset = 0; 
     param.flyscan_dutycycle = 1;
-    rng('default');
-    rng('shuffle');
+    %rng('default');
+    %rng('shuffle');
 
     % convergence check - stop reconstruction if fourier error is larger than the previous one by given (relative) threshold. 
     param.fourier_error_threshold = inf; % default: no convergence check.

--- a/ptycho/+engines/+GPU_MS/+initialize/private/get_close_indices.m
+++ b/ptycho/+engines/+GPU_MS/+initialize/private/get_close_indices.m
@@ -97,7 +97,7 @@ if Nsets == 1 && grouping >= self.Npos
     return
 end
 
-rng default
+%rng default
 
 for kk = 1:Nsets
     % take them sequentially but with random offset 
@@ -243,7 +243,7 @@ verbose(0,'=== Position clusters found in %i iterations in %3.2gs', iter, cluste
 verbose(0,'=== Position clusters refined in %i iterations in %3.2gs', iter, cluster_refinement_time)
 
 
-rng shuffle 
+%rng shuffle 
 
 if verbose()  > 1 && Ngroups_sizes > 1
     warning('Unequal group sizes, it may cause slower calculation')


### PR DESCRIPTION
Disable RNG seed setter in the model probe function and the GPU engines.
(Hopefully) this allows external scripts to set the RNG seed in ptychographic reconstruction.