### PR TITLE
add an argument for base_path in the ellipse_fit_positions

### DIFF
--- a/tomo/utils/ellipse_fit_positions.m
+++ b/tomo/utils/ellipse_fit_positions.m
@@ -1,4 +1,4 @@
-function ellipse_fit_positions(samposx,samposy,scans,lamni_fit_file)
+function ellipse_fit_positions(samposx,samposy,scans,lamni_fit_file,bath_path)
 
 % addpath ../
 % 
@@ -20,7 +20,7 @@ plot(samposx,samposy,'o')
 if exist('lamni_fit_file')
     [~,lamni_name,~] = fileparts(lamni_fit_file);
     %theta = prepare.read_angles_from_position_files('~/specES1/scan_positions/scan_%05d.dat',scans);
-    theta = prepare.read_angles_from_position_files('/mnt/micdata2/lamni/2020-2/comm_33IDD_2/specES1/scan_positions/scan_%05d.dat',scans);
+    theta = prepare.read_angles_from_position_files(strcat(bath_path,'/scan_positions/scan_%05d.dat'),scans);
     
     theta_interp = [min(theta)-1:max(theta)+1];
     


### PR DESCRIPTION
Add an argument for base_path in the ellipse_fit_positions. This allows users to work with instruments outside PSI.