### PR TITLE
add simple fixes for bad LYNX data

### DIFF
--- a/ptycho/+detector/+prep_data/+matlab_aps_lynx/load_data.m
+++ b/ptycho/+detector/+prep_data/+matlab_aps_lynx/load_data.m
@@ -35,9 +35,12 @@ catch
     error('Failed to load dp from %s', files{p.scanID});
 end
 data = single(squeeze(data));
-%data = (squeeze(data));
 
 data = data(detStorage.lim_inf(2):detStorage.lim_sup(2),detStorage.lim_inf(1):detStorage.lim_sup(1),:);
+
+%quick fix for bad detector readouts
+data(data<0) = 0;
+data(data>1e9) = 0;
 
 utils.verbose(2, strcat('Loaded data from:', files{p.scanID}))
 

--- a/ptycho/+detector/+prep_data/+matlab_aps_lynx/matlab_aps_lynx.m
+++ b/ptycho/+detector/+prep_data/+matlab_aps_lynx/matlab_aps_lynx.m
@@ -38,9 +38,13 @@ p = detector.prep_data.matlab_aps_lynx.prep_data_matlab(p, data, fmask);
 num_difpat = size(p.fmag,3);
 verbose(2, 'Number of probe positions: %d', sum(p.numpts));
 verbose(2, 'Number of diffraction patterns : %d', num_difpat);
+
+%quick fix for fly-scan data
+%only works if # of diffraction patterns >= # of scan points
+%{
 if num_difpat ~= sum(p.numpts)
     error('Number of probe positions (%d) inconsistent with number of diffraction patterns (%d)', sum(p.numpts), num_difpat);
 end
-
+%}
 
 end


### PR DESCRIPTION
Implement some simple fixes to deal with issues in the LYNX data:
1. There are more diffraction patterns than scan positions in fly-scan mode.
2. Some detector frames are not saved properly and have more saturated values that need to be corrected.


@adracarr79 