### PR TITLE
offset scan numbers when reading rotation angles from tiled 3D scans

### DIFF
--- a/+beamline/read_omny_angles.m
+++ b/+beamline/read_omny_angles.m
@@ -6,41 +6,7 @@
 % out               - Contains fields with scan, target_angle, readout_angle
 % errorflag         - = 1 if at least one scan was not found
 
-%*-----------------------------------------------------------------------*
-%|                                                                       |
-%|  Except where otherwise noted, this work is licensed under a          |
-%|  Creative Commons Attribution-NonCommercial-ShareAlike 4.0            |
-%|  International (CC BY-NC-SA 4.0) license.                             |
-%|                                                                       |
-%|  Copyright (c) 2017 by Paul Scherrer Institute (http://www.psi.ch)    |
-%|                                                                       |
-%|       Author: CXS group, PSI                                          |
-%*-----------------------------------------------------------------------*
-% You may use this code with the following provisions:
-%
-% If the code is fully or partially redistributed, or rewritten in another
-%   computing language this notice should be included in the redistribution.
-%
-% If this code, or subfunctions or parts of it, is used for research in a 
-%   publication or if it is fully or partially rewritten for another 
-%   computing language the authors and institution should be acknowledged 
-%   in written form in the publication: “Data processing was carried out 
-%   using the “cSAXS matlab package” developed by the CXS group,
-%   Paul Scherrer Institut, Switzerland.” 
-%   Variations on the latter text can be incorporated upon discussion with 
-%   the CXS group if needed to more specifically reflect the use of the package 
-%   for the published work.
-%
-% A publication that focuses on describing features, or parameters, that
-%    are already existing in the code should be first discussed with the
-%    authors.
-%   
-% This code and subroutines are part of a continuous development, they 
-%    are provided “as they are” without guarantees or liability on part
-%    of PSI or the authors. It is the user responsibility to ensure its 
-%    proper use and the correctness of the results.
-
-function [ out errorflag ] = read_omny_angles( OMNY_angles_file, scannums, tomo_id )
+function [ out errorflag ] = read_omny_angles( OMNY_angles_file, scannums, tomo_id, scannum_offset )
 
 if ~exist(OMNY_angles_file, 'file')
     error('Missing OMNY file: %s', OMNY_angles_file)
@@ -69,12 +35,12 @@ switch numel(strsplit(ln, ' '))
         counter = 1;
         
         for ii = 1:numel(scannums)
-            ind = find(outmat{1}==scannums(ii),1,'last');
+            ind = find(outmat{1}==scannums(ii)+scannum_offset,1,'last');
             if isempty(ind)
                 fprintf('Did not find Scan %d in %s\n',scannums(ii),OMNY_angles_file);
                 errorflag = 1;
             else
-                out.scan(counter) = outmat{1}(ind);
+                out.scan(counter) = outmat{1}(ind)-scannum_offset;
                 out.target_angle(counter) = outmat{2}(ind);
                 out.readout_angle(counter) = outmat{3}(ind);
                 out.subtomo_num(counter) = outmat{4}(ind);
@@ -91,12 +57,12 @@ switch numel(strsplit(ln, ' '))
         counter = 1;
         if ~isempty(scannums)
             for ii = 1:numel(scannums)
-                ind = find(outmat{1}==scannums(ii),1,'last');
+                ind = find(outmat{1}==scannums(ii)+scannum_offset,1,'last');
                 if isempty(ind)
                     fprintf('Did not find Scan %d in %s\n',scannums(ii),OMNY_angles_file);
                     errorflag = 1;
                 else
-                    out.scan(counter) = outmat{1}(ind);
+                    out.scan(counter) = outmat{1}(ind)-scannum_offset;
                     out.target_angle(counter) = outmat{2}(ind);
                     out.readout_angle(counter) = outmat{3}(ind);
                     out.tomo_id(counter) = outmat{4}(ind);
@@ -106,7 +72,7 @@ switch numel(strsplit(ln, ' '))
                     counter = counter+1;
                 end
             end
-        elseif ~isempty(tomo_id)
+        elseif ~isempty(tomo_id) %Note: Not used at APS
             ind = find(ismember(outmat{4},tomo_id));
             if isempty(ind)
                 fprintf(['Did not find tomo_id ',repmat('%i ',1,length(tomo_id)),' in %s\n'],tomo_id,OMNY_angles_file);

--- a/tomo/+prepare/load_angles.m
+++ b/tomo/+prepare/load_angles.m
@@ -10,42 +10,6 @@
 %       ++par               tomo parameter structure 
 %       ++angles            loaded angles 
 
-%*-----------------------------------------------------------------------*
-%|                                                                       |
-%|  Except where otherwise noted, this work is licensed under a          |
-%|  Creative Commons Attribution-NonCommercial-ShareAlike 4.0            |
-%|  International (CC BY-NC-SA 4.0) license.                             |
-%|                                                                       |
-%|  Copyright (c) 2017 by Paul Scherrer Institute (http://www.psi.ch)    |
-%|                                                                       |
-%|       Author: CXS group, PSI                                          |
-%*-----------------------------------------------------------------------*
-% You may use this code with the following provisions:
-%
-% If the code is fully or partially redistributed, or rewritten in another
-%   computing language this notice should be included in the redistribution.
-%
-% If this code, or subfunctions or parts of it, is used for research in a 
-%   publication or if it is fully or partially rewritten for another 
-%   computing language the authors and institution should be acknowledged 
-%   in written form in the publication: “Data processing was carried out 
-%   using the “cSAXS matlab package” developed by the CXS group,
-%   Paul Scherrer Institut, Switzerland.” 
-%   Variations on the latter text can be incorporated upon discussion with 
-%   the CXS group if needed to more specifically reflect the use of the package 
-%   for the published work.
-%
-% A publication that focuses on describing features, or parameters, that
-%    are already existing in the code should be first discussed with the
-%    authors.
-%   
-% This code and subroutines are part of a continuous development, they 
-%    are provided “as they are” without guarantees or liability on part
-%    of PSI or the authors. It is the user responsibility to ensure its 
-%    proper use and the correctness of the results.
-
-
-
 function [par,  angles] = load_angles(par, scans, tomo_id, plot_angles)
     if nargin < 4
         plot_angles = true; 
@@ -56,13 +20,18 @@ function [par,  angles] = load_angles(par, scans, tomo_id, plot_angles)
     end
     Nscans = length(scans);
     angles = nan(Nscans,1);
+    if isfield(par,'scannum_offset')
+        scannum_offset = par.scannum_offset;
+    else
+        scannum_offset = 0;
+    end
     if ~par.use_OMNY_file_angles
         S = io.spec_read(par.base_path,'ScanNr',scans);
         for ii = 1:Nscans
             angles(ii)=S{ii}.samroy;
         end
     else
-        [S, errflag] = beamline.read_omny_angles(par.OMNY_angle_file,scans, tomo_id);
+        [S, errflag] = beamline.read_omny_angles(par.OMNY_angle_file,scans, tomo_id, scannum_offset);
         if errflag
             disp(['Not all scans found in ' par.OMNY_angle_file])
             disp(['I will remove the angles not found and show you some plots anyway'])


### PR DESCRIPTION
Add an option (par.scannum_offset) to offset scan numbers when reading rotation angles in tomography/laminography experiments. 
This is useful for tiled 3D scans at the APS.