### PR TITLE
add an option to disable probe orthogonalization during ptychographic reconstruction

### DIFF
--- a/ptycho/+engines/+GPU/+initialize/get_defaults.m
+++ b/ptycho/+engines/+GPU/+initialize/get_defaults.m
@@ -57,6 +57,7 @@ function [param] = get_defaults
     param.remove_object_ambiguity = true;    % remove intensity ambiguity between the object and the probes 
     param.variable_probe = false;           % Use SVD to account for variable illumination during a single (coupled) scan
     param.apply_subpix_shift = false;       % apply FFT-based subpixel shift, important for good position refinement but it is slow
+    param.ortho_probe_modes = true;       % orthogonalize incoherent probe modes after each iteration
 
     param.probe_geometry_model = {'scale', 'asymmetry', 'rotation', 'shear'};  % list of free parameters in the geometry model
     param.probe_position_search = inf;

--- a/ptycho/+engines/+GPU/ptycho_solver.m
+++ b/ptycho/+engines/+GPU/ptycho_solver.m
@@ -405,7 +405,7 @@ while iter <= par.number_iterations %modified by YJ: use while loop for time-res
     end
     
     %% probe orthogonalization
-    if par.probe_modes > par.Nrec && (~is_method(par, 'DM') || iter == par.number_iterations)
+    if par.ortho_probe_modes && par.probe_modes > par.Nrec && (~is_method(par, 'DM') || iter == par.number_iterations)
         %  orthogonalization of incoherent probe modes 
         if is_used(par, 'fly_scan')
             probes = self.probe;

--- a/ptycho/+engines/+GPU_MS/+initialize/get_defaults.m
+++ b/ptycho/+engines/+GPU_MS/+initialize/get_defaults.m
@@ -58,6 +58,7 @@ function [param] = get_defaults
     param.remove_object_ambiguity = true;    % remove intensity ambiguity between the object and the probes 
     param.variable_probe = false;           % Use SVD to account for variable illumination during a single (coupled) scan
     param.apply_subpix_shift = false;       % apply FFT-based subpixel shift, important for good position refinement but it is slow
+    param.ortho_probe_modes = true;       % orthogonalize incoherent probe modes after each iteration
 
     param.probe_geometry_model = {'scale', 'asymmetry', 'rotation', 'shear'};  % list of free parameters in the geometry model
     param.probe_position_search = inf;

--- a/ptycho/+engines/+GPU_MS/ptycho_solver.m
+++ b/ptycho/+engines/+GPU_MS/ptycho_solver.m
@@ -398,7 +398,7 @@ for iter =  (1-par.initial_probe_rescaling):par.number_iterations
     end
     
     %% probe orthogonalization 
-    if par.probe_modes > par.Nrec && (~is_method(par, 'DM') || iter == par.number_iterations)
+    if par.ortho_probe_modes &&  par.probe_modes > par.Nrec && (~is_method(par, 'DM') || iter == par.number_iterations)
         %  orthogonalization of incoherent probe modes 
         if is_used(par, 'fly_scan')
             probes = self.probe;


### PR DESCRIPTION
Add a new variable, eng.ortho_probe_modes (default = true), to disable probe orthogonalization during ptychographic reconstruction. 
This may prevent artifacts that are caused by "hot spots" in reconstructed probes.