### PR TITLE
more robust ways for estimating region of interests in limited-FOV ptycho-tomography

### DIFF
--- a/tomo/+tomo/apply_reliability_region.m
+++ b/tomo/+tomo/apply_reliability_region.m
@@ -1,0 +1,18 @@
+% output = apply_reliability_region(input, weight)
+% Apply weighting functions to a stack of projections
+
+% Inputs: 
+%   **input             - real or complex image stack 
+%   **weight            - weights for each projection
+% 
+% *returns* 
+%   ++output            - projections multiplied by their weights
+
+% Written by YJ
+
+function output = apply_reliability_region(input, weight)
+    output = single(zeros(size(input)));
+    for i=1:size(input,3)
+        output(:,:,i) = gather(input(:,:,i)) .* gather(weight(:,:,i));
+    end
+end

--- a/tomo/+tomo/apply_reliability_region.m
+++ b/tomo/+tomo/apply_reliability_region.m
@@ -1,13 +1,11 @@
 % output = apply_reliability_region(input, weight)
 % Apply weighting functions to a stack of projections
-
 % Inputs: 
 %   **input             - real or complex image stack 
 %   **weight            - weights for each projection
 % 
 % *returns* 
 %   ++output            - projections multiplied by their weights
-
 % Written by YJ
 
 function output = apply_reliability_region(input, weight)

--- a/tomo/+tomo/estimate_reliability_region_grad.m
+++ b/tomo/+tomo/estimate_reliability_region_grad.m
@@ -3,27 +3,27 @@
 % The method is base on gradient magnitude of the image 
 % Written by YJ
 
-function weight_sino = estimate_reliability_region_grad(sinogram, fill, erode_mat)
-    %{
-    disp(size(sinogram))
-    [Gmag,~] = imgradient(gather(sinogram));
-    sinogram_temp = imfill(Gmag,fill);
-    level = graythresh(sinogram_temp);
-    weight_sino_temp = imbinarize(sinogram_temp,level);
-    weight_sino = imerode(weight_sino_temp,erode_mat);
-    %}
-    
+function weight_sino = estimate_reliability_region_grad(sinogram, fill, SE)
+
     weight_sino = single(zeros(size(sinogram)));
+    
     for i=1:size(sinogram,3)
         if ~isreal(sinogram)
-            [Gmag,~] = imgradient(angle(sinogram(:,:,i)));
+            sinogram_temp = angle(sinogram(:,:,i));
         else
-            [Gmag,~] = imgradient(sinogram(:,:,i));
+            sinogram_temp = sinogram(:,:,i);
         end
+        
+        H = fspecial('unsharp');
+        sinogram_temp = imfilter(sinogram_temp,H);
+        [Gmag,~] = imgradient(sinogram_temp);
         sinogram_temp = imfill(Gmag,fill);
         level = graythresh(gather(sinogram_temp));
+        
         weight_sino_temp = imbinarize(gather(sinogram_temp),level);
-        weight_sino(:,:,i) = imerode(weight_sino_temp,erode_mat);
+        weight_sino_temp = imclose(weight_sino_temp,SE);
+        weight_sino_temp = imerode(weight_sino_temp,SE);
+        weight_sino(:,:,i) = weight_sino_temp;
+        
     end
-    
 end


### PR DESCRIPTION
Refactor the "estimate_reliability_region_grad" function by adding more features for image processing.
1. New options: unsharp image filter and close morphological transform.
2. Allow different disk radii for different projections.
3. Add an auxiliary function (apply_reliability_region) for faster processing with GPU parallelization.