### PR TITLE
fix variable type bug in estimate_reliability_region_grad

### DIFF
--- a/tomo/+tomo/estimate_reliability_region_grad.m
+++ b/tomo/+tomo/estimate_reliability_region_grad.m
@@ -14,6 +14,9 @@ function weights = estimate_reliability_region_grad(input, r_close, r_erode, par
 
     weights = single(zeros(size(input)));
     
+    r_close = double(gather(r_close));
+    r_erode = double(gather(r_erode));
+    
     for i=1:size(input,3)
         if ~isreal(input)
             sinogram_temp = angle(input(:,:,i));


### PR DESCRIPTION
Alway convert "r_close" and "r_erode" to double to prevent potential errors when the function is used in tomo.block_fun.
An error may occur if the data size is small.