### PR TITLE
keep Matlab figures open when starting ptychographic reconstructions

### DIFF
--- a/ptycho/+core/initialize_ptycho.m
+++ b/ptycho/+core/initialize_ptycho.m
@@ -28,9 +28,11 @@ end
 if ~isfield(p.save, 'store_images')
     p.save.store_images = true;
 end
-if ~p.save.store_images
-    close all
-end
+
+%disabled by YJ
+%if ~p.save.store_images
+%    close all
+%end
 
 % prepare container for meta data
 assert( isnumeric(p.scan_number), 'p.scan_number has to contain an integer number')


### PR DESCRIPTION
Always keep Matlab figures open when starting ptychographic reconstructions.
This disables "close all" in initialize_ptycho.m, which may introduce errors related to I/O. I'll make this change for now so that the reconstruction function can be used with external functions such as Bayesian optimization.