### PR TITLE
allow users to specify a pad value when initializing objects with the GPU engines

### DIFF
--- a/ptycho/+engines/+GPU/+initialize/load_from_p.m
+++ b/ptycho/+engines/+GPU/+initialize/load_from_p.m
@@ -289,10 +289,14 @@ function [self, param, p] = load_from_p(param, p)
         for layer = 1:size(self.object,2)
             % if needed expand the object to allow position refinement 
             % and shift for consistency with the CPU code
-            self.object{i,layer} = imshift_fast(self.object{i,layer},1,1,self.Np_o, 'nearest', mean(self.object{i,layer}(:)));
+            if isfield(p, 'init_obj_pad_value')
+                self.object{i,layer} = imshift_fast(self.object{i,layer},1,1,self.Np_o, 'nearest', p.init_obj_pad_value);
+            else
+                self.object{i,layer} = imshift_fast(self.object{i,layer},1,1,self.Np_o, 'nearest', min(self.object{i,layer}(:)));
+            end
         end
     end
-    
+
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     %% load data, mask noise %%%%
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/ptycho/+engines/+GPU_MS/+initialize/load_from_p.m
+++ b/ptycho/+engines/+GPU_MS/+initialize/load_from_p.m
@@ -290,11 +290,14 @@ function [self, param, p] = load_from_p(param, p)
         for layer = 1:size(self.object,2)
             % if needed expand the object to allow position refinement 
             % and shift for consistency with the CPU code
-            self.object{i,layer} = imshift_fast(self.object{i,layer},1,1,self.Np_o, 'nearest', mean(self.object{i,layer}(:)));
+            if isfield(p, 'init_obj_pad_value')
+                self.object{i,layer} = imshift_fast(self.object{i,layer},1,1,self.Np_o, 'nearest', p.init_obj_pad_value);
+            else
+                self.object{i,layer} = imshift_fast(self.object{i,layer},1,1,self.Np_o, 'nearest', min(self.object{i,layer}(:)));
+            end
         end
     end
-    
-        
+     
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     %% load data, mask noise %%%%
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Added a new engine variable (eng.init_obj_pad_value) to allow users to specify a pad value when initializing the object function. 
The old and default setting, which uses the minimal value of the previous object, may not work well if the previous object contains phase-wrapping artifacts, causing unnecessary problems in post-analysis.
For multislice ptychography, it may be even better to specify different pad values for different slices. For now, I only allow a constant value for simplicity.
