### PR TITLE
load ptychographic reconstructions without variable probe correction into a tomography pipeline

### DIFF
--- a/tomo/utils/find_ML_recon_files_names.m
+++ b/tomo/utils/find_ML_recon_files_names.m
@@ -11,85 +11,53 @@
 %   ++filename           filename of the found scan 
 
 
-function [filename,method,roi,scanNo] = find_ML_recon_files_names(par, scan_num)
+function [filename, method, roi, scanNo] = find_ML_recon_files_names(par, scan_num)
     N_roi = linspace(1,length(par.MLrecon.roi),length(par.MLrecon.roi));
-    [N_roi_temp, Nprobe_s_temp,var_probe_modes_s_temp] = ndgrid(N_roi,par.MLrecon.Nprobes, par.MLrecon.var_probe_modes);
-    N_roi_temp = reshape(N_roi_temp,[],1);
-    Nprobe_s_temp = reshape(Nprobe_s_temp,[],1);
-    var_probe_modes_s_temp = reshape(var_probe_modes_s_temp,[],1);
     filename = [];
     scanNo = num2str(scan_num);
-    for i=1:length(Nprobe_s_temp)
-        roi = par.MLrecon.roi{N_roi_temp(i)};
-        Nprobe = Nprobe_s_temp(i);
-        vp_modes = var_probe_modes_s_temp(i);
-        %method = sprintf(par.MLrecon.method,Nprobe,vp_modes,Nprobe,vp_modes);
-        method = '';
-        for j=1:length(par.MLrecon.method)
-            method = strcat(method,sprintf(par.MLrecon.method{j},Nprobe,vp_modes));
-        end
-        
-        filename_temp = strcat(par.MLrecon.path, sprintf(par.scan_string_format, scan_num),roi, method,'/Niter',num2str(par.MLrecon.Niter),'.mat');
-        %disp('filename_temp:')
-        %disp(filename_temp)
-        if ~isempty(dir(filename_temp))
-            d = dir(filename_temp);
-            %filename = filename_temp;
-            filename = strcat(d(1).folder,'/',d(1).name);
-            %disp('filename:')
-            %disp(filename)
-            %disp(strcat(d.folder,'/',d.name))
 
-            %disp(strcat(sprintf(par.scan_string_format, scan_num),'--',method,'Niter',num2str(par.MLrecon.Niter),'.mat'))
-            break
+    if isempty(par.MLrecon.var_probe_modes) % no variable probe correction
+        [N_roi_temp, Nprobe_s_temp] = ndgrid(N_roi, par.MLrecon.Nprobes);
+        N_roi_temp = reshape(N_roi_temp,[],1);
+        Nprobe_s_temp = reshape(Nprobe_s_temp,[],1);
+        for i=1:length(Nprobe_s_temp)
+            roi = par.MLrecon.roi{N_roi_temp(i)};
+            Nprobe = Nprobe_s_temp(i);
+            method = '';
+            for j=1:length(par.MLrecon.method)
+                method = strcat(method,sprintf(par.MLrecon.method{j},Nprobe));
+            end
+            filename_temp = strcat(par.MLrecon.path, sprintf(par.scan_string_format, scan_num),roi, method,'/Niter',num2str(par.MLrecon.Niter),'.mat');
+            if ~isempty(dir(filename_temp))
+                d = dir(filename_temp);
+                filename = strcat(d(end).folder,'/',d(end).name);
+                break
+            end
         end
-    end
-    
-    %{
-    %bug?
-    %%%data_in_subfolders = exist(fullfile(par.analysis_path, 'S00000-00999'), 'dir');
-    data_in_subfolders = exist(fullfile(par.analysis_path, 'S02000-02999'), 'dir');
-    
-    if data_in_subfolders
-        % new x12sa path format
-        % bug?
-        %%%path = fullfile(par.analysis_path, utils.compile_x12sa_dirname(scan_num) , [par.fileprefix '*' par.filesuffix '*.' par.file_extension]); 
-    	%modified by YJ
-        path = fullfile(par.analysis_path, utils.compile_x12sa_dirname(scan_num) , [sprintf('S%05i',scan_num), par.fileprefix '*' par.filesuffix '*.' par.file_extension]); 
-        
     else
-        % compatibility option for original analysis paths 
-        %path = fullfile(par.analysis_path,sprintf('S%05i',scan_num),[par.fileprefix '*' par.filesuffix '*.' par.file_extension]); 
-        % path = strcat(par.analysis_path,sprintf(par.scan_string_format,scan_num),'.', par.file_extension); 
-        %generate a list of possibe recon parameters
-        %current support: number of probe modes; number of OPR modes
-        [Nprobe_s_temp,var_probe_modes_s_temp] = meshgrid(par.MLrecon.Nprobes, par.MLrecon.var_probe_modes);
+        [N_roi_temp, Nprobe_s_temp,var_probe_modes_s_temp] = ndgrid(N_roi, par.MLrecon.Nprobes, par.MLrecon.var_probe_modes);
+        N_roi_temp = reshape(N_roi_temp,[],1);
         Nprobe_s_temp = reshape(Nprobe_s_temp,[],1);
         var_probe_modes_s_temp = reshape(var_probe_modes_s_temp,[],1);
+        
         for i=1:length(Nprobe_s_temp)
+            roi = par.MLrecon.roi{N_roi_temp(i)};
             Nprobe = Nprobe_s_temp(i);
             vp_modes = var_probe_modes_s_temp(i);
-            method = sprintf(par.MLrecon.method,Nprobe,vp_modes,Nprobe,vp_modes);
-            filename = strcat(par.MLrecon.path, sprintf(par.scan_string_format, scan_num),par.MLrecon.roi, method,'Niter',num2str(par.MLrecon.Niter),'.mat');
-            if ~isempty(dir(filename))
-                disp(strcat(sprintf(par.scan_string_format, scan_num),'--',method,'Niter',num2str(par.MLrecon.Niter),'.mat'))
+            method = '';
+            for j=1:length(par.MLrecon.method)
+                method = strcat(method,sprintf(par.MLrecon.method{j},Nprobe,vp_modes));
+            end
+            filename_temp = strcat(par.MLrecon.path, sprintf(par.scan_string_format, scan_num),roi, method,'/Niter',num2str(par.MLrecon.Niter),'.mat');
+            if ~isempty(dir(filename_temp))
+                d = dir(filename_temp);
+                filename = strcat(d(end).folder,'/',d(end).name);
                 break
             end
         end
     end
-    %}
-    %{
-    while contains(path, '**')
-        path = replace(path, '**', '*'); % prevent failure when path string contains multiple asterix
+    
+    if isfield(par.MLrecon, 'print_file_path') && par.MLrecon.print_file_path
+        disp(filename)
     end
-    path = utils.abspath(path); 
-    path = dir(path); 
-    if isempty(path)
-        filename = []; 
-        return
-    end
-    % take the last file fitting the constraints 
-    [~,ind]=sort([path.datenum]);
-    filename = fullfile(path(ind(1)).folder, path(ind(1)).name);
-    %}
 end


### PR DESCRIPTION
Rewrite the utility function (find_ML_recon_files_names.m) so that it can search for ptychographic reconstructions without variable probe correction. 
Also, added a new option (par.MLrecon.print_file_path) to print out file names during debugging.