### PR TITLE
pad initial object with the mean value of previous objects in ptychographic reconstruction

### DIFF
--- a/ptycho/+engines/+GPU/+initialize/load_from_p.m
+++ b/ptycho/+engines/+GPU/+initialize/load_from_p.m
@@ -292,7 +292,7 @@ function [self, param, p] = load_from_p(param, p)
             if isfield(p, 'init_obj_pad_value')
                 self.object{i,layer} = imshift_fast(self.object{i,layer},1,1,self.Np_o, 'nearest', p.init_obj_pad_value);
             else
-                self.object{i,layer} = imshift_fast(self.object{i,layer},1,1,self.Np_o, 'nearest', min(self.object{i,layer}(:)));
+                self.object{i,layer} = imshift_fast(self.object{i,layer},1,1,self.Np_o, 'nearest', mean(self.object{i,layer}(:)));
             end
         end
     end

--- a/ptycho/+engines/+GPU_MS/+initialize/load_from_p.m
+++ b/ptycho/+engines/+GPU_MS/+initialize/load_from_p.m
@@ -293,7 +293,7 @@ function [self, param, p] = load_from_p(param, p)
             if isfield(p, 'init_obj_pad_value')
                 self.object{i,layer} = imshift_fast(self.object{i,layer},1,1,self.Np_o, 'nearest', p.init_obj_pad_value);
             else
-                self.object{i,layer} = imshift_fast(self.object{i,layer},1,1,self.Np_o, 'nearest', min(self.object{i,layer}(:)));
+                self.object{i,layer} = imshift_fast(self.object{i,layer},1,1,self.Np_o, 'nearest', mean(self.object{i,layer}(:)));
             end
         end
     end


### PR DESCRIPTION
Fix a bug introduced in #115 , which pads initial objects with the minimal value of the previous object.
This PR reverts to the original implementation using the mean pixel value.