### PR TITLE
increase GPU array size limit for tomographic reconstruction

### DIFF
--- a/+astra/ASTRA_find_optimal_split.m
+++ b/+astra/ASTRA_find_optimal_split.m
@@ -11,43 +11,6 @@
 % Outputs:
 %     ++split - volume / angle split - [split_x,split_y,split_z,split_angles]   
 
-
-%*-----------------------------------------------------------------------*
-%|                                                                       |
-%|  Except where otherwise noted, this work is licensed under a          |
-%|  Creative Commons Attribution-NonCommercial-ShareAlike 4.0            |
-%|  International (CC BY-NC-SA 4.0) license.                             |
-%|                                                                       |
-%|  Copyright (c) 2017 by Paul Scherrer Institute (http://www.psi.ch)    |
-%|                                                                       |
-%|       Author: CXS group, PSI                                          |
-%*-----------------------------------------------------------------------*
-% You may use this code with the following provisions:
-%
-% If the code is fully or partially redistributed, or rewritten in another
-%   computing language this notice should be included in the redistribution.
-%
-% If this code, or subfunctions or parts of it, is used for research in a 
-%   publication or if it is fully or partially rewritten for another 
-%   computing language the authors and institution should be acknowledged 
-%   in written form in the publication: “Data processing was carried out 
-%   using the “cSAXS matlab package” developed by the CXS group,
-%   Paul Scherrer Institut, Switzerland.” 
-%   Variations on the latter text can be incorporated upon discussion with 
-%   the CXS group if needed to more specifically reflect the use of the package 
-%   for the published work.
-%
-% A publication that focuses on describing features, or parameters, that
-%    are already existing in the code should be first discussed with the
-%    authors.
-%   
-% This code and subroutines are part of a continuous development, they 
-%    are provided “as they are” without guarantees or liability on part
-%    of PSI or the authors. It is the user responsibility to ensure its 
-%    proper use and the correctness of the results.
-
-
-
 function split = ASTRA_find_optimal_split(cfg, num_gpu, angle_blocks, propagator)
   
     if gpuDeviceCount == 0
@@ -80,8 +43,8 @@ function split = ASTRA_find_optimal_split(cfg, num_gpu, angle_blocks, propagator
     split = max(split, [1,1,split(3)*ceil( ((cfg.iVolX*cfg.iVolY*cfg.iVolZ  )/ prod(split)/num_gpu) / double(intmax('int32')) )]); % maximal array on GPU limit 
 
     if ismember(lower(propagator), {'back','both'})
-        % if projection would be larger than 4096x4096 -> split the reconstruction volume 
-        split = max(split, [cfg.iProjU, cfg.iProjU,  cfg.iProjV]/4096 ); % texture memory limit 
+        % if projection would be larger than 8192x8192 -> split the reconstruction volume 
+        split = max(split, [cfg.iProjU, cfg.iProjU,  cfg.iProjV]/8192 ); % texture memory limit 
     end
 
     % projection size limitation  +   astra allows only < 1024 angles

--- a/+astra/Atx_partial.m
+++ b/+astra/Atx_partial.m
@@ -24,42 +24,6 @@
 %  (Linux, GCC 4.8.5)   mexcuda -outdir private  ASTRA_GPU_wrapper/ASTRA_GPU_wrapper.cu ASTRA_GPU_wrapper/util3d.cu ASTRA_GPU_wrapper/par3d_fp.cu ASTRA_GPU_wrapper/par3d_bp.cu
 %  (Windows)  mexcuda -outdir private  ASTRA_GPU_wrapper\ASTRA_GPU_wrapper.cu ASTRA_GPU_wrapper\util3d.cu ASTRA_GPU_wrapper\par3d_fp.cu ASTRA_GPU_wrapper\par3d_bp.cu
 
-    
-%*-----------------------------------------------------------------------*
-%|                                                                       |
-%|  Except where otherwise noted, this work is licensed under a          |
-%|  Creative Commons Attribution-NonCommercial-ShareAlike 4.0            |
-%|  International (CC BY-NC-SA 4.0) license.                             |
-%|                                                                       |
-%|  Copyright (c) 2017 by Paul Scherrer Institute (http://www.psi.ch)    |
-%|                                                                       |
-%|       Author: CXS group, PSI                                          |
-%*-----------------------------------------------------------------------*
-% You may use this code with the following provisions:
-%
-% If the code is fully or partially redistributed, or rewritten in another
-%   computing language this notice should be included in the redistribution.
-%
-% If this code, or subfunctions or parts of it, is used for research in a 
-%   publication or if it is fully or partially rewritten for another 
-%   computing language the authors and institution should be acknowledged 
-%   in written form in the publication: “Data processing was carried out 
-%   using the “cSAXS matlab package” developed by the CXS group,
-%   Paul Scherrer Institut, Switzerland.” 
-%   Variations on the latter text can be incorporated upon discussion with 
-%   the CXS group if needed to more specifically reflect the use of the package 
-%   for the published work.
-%
-% A publication that focuses on describing features, or parameters, that
-%    are already existing in the code should be first discussed with the
-%    authors.
-%   
-% This code and subroutines are part of a continuous development, they 
-%    are provided “as they are” without guarantees or liability on part
-%    of PSI or the authors. It is the user responsibility to ensure its 
-%    proper use and the correctness of the results.
-
-
 function vol_full = Atx_partial(projData, cfg, vectors,split,varargin)
 
 
@@ -117,7 +81,7 @@ function vol_full = Atx_partial(projData, cfg, vectors,split,varargin)
         
     % input parameters check
     if ismatrix(projData); projSize = [projSize,1]; end
-    assert(max(cfg.iProjU, cfg.iProjV) <= 4096, 'Sinogram exceed maximal size allowed by GPU (4096)')
+    assert(max(cfg.iProjU, cfg.iProjV) <= 8192, 'Sinogram exceed maximal size allowed by GPU (8192)')
     assert(all(projSize==[cfg.iProjV,cfg.iProjU,cfg.iProjAngles]), 'Wrong inputs size')
     assert(all(size(vectors)==[cfg.iProjAngles,12]), 'Wrong vectors size')
 


### PR DESCRIPTION
Increase GPU array size limit from 4096 to 8192. 
A more elegant way is splitting the volume into subregions, but this is a simple fix to prevent errors caused by size checks.

(GPU reference: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications-technical-specifications-per-compute-capability)
