### PR TITLE
Convolve the exit wave's Fourier intensity with a Gaussian kernel in ptychographic reconstruction

### DIFF
--- a/ptycho/+engines/+GPU/+initialize/load_from_p.m
+++ b/ptycho/+engines/+GPU/+initialize/load_from_p.m
@@ -421,7 +421,14 @@ function [self, param, p] = load_from_p(param, p)
     end
     
     self.lambda = p.lambda;
-    self.diff_pattern_blur = 0;  % incoherent smoothing 
+    
+    if check_option(p,'diff_pattern_blur') && p.diff_pattern_blur > 0
+        verbose(0, 'Account for detector blur with a Gaussian kernel (sigma=%0.1f)', p.diff_pattern_blur)
+        self.diff_pattern_blur = p.diff_pattern_blur;
+    else
+        self.diff_pattern_blur = 0;  % incoherent smoothing 
+    end
+    
     self.modes = []; 
            
     % keep p structure for plotting purposes 
@@ -461,3 +468,4 @@ function [self, param, p] = load_from_p(param, p)
 
     
 end
+

--- a/ptycho/+engines/+GPU/private/get_reciprocal_model.m
+++ b/ptycho/+engines/+GPU/private/get_reciprocal_model.m
@@ -17,64 +17,6 @@
 % ++ cache          structure with precalculated values 
 % ++ self           structure containing inputs: e.g. current reconstruction results, data, mask, positions, pixel size, ..
 
-
-
-% Academic License Agreement
-% 
-% Source Code
-% 
-% Introduction 
-% •	This license agreement sets forth the terms and conditions under which the PAUL SCHERRER INSTITUT (PSI), CH-5232 Villigen-PSI, Switzerland (hereafter "LICENSOR") 
-%   will grant you (hereafter "LICENSEE") a royalty-free, non-exclusive license for academic, non-commercial purposes only (hereafter "LICENSE") to use the cSAXS 
-%   ptychography MATLAB package computer software program and associated documentation furnished hereunder (hereafter "PROGRAM").
-% 
-% Terms and Conditions of the LICENSE
-% 1.	LICENSOR grants to LICENSEE a royalty-free, non-exclusive license to use the PROGRAM for academic, non-commercial purposes, upon the terms and conditions 
-%       hereinafter set out and until termination of this license as set forth below.
-% 2.	LICENSEE acknowledges that the PROGRAM is a research tool still in the development stage. The PROGRAM is provided without any related services, improvements 
-%       or warranties from LICENSOR and that the LICENSE is entered into in order to enable others to utilize the PROGRAM in their academic activities. It is the 
-%       LICENSEE’s responsibility to ensure its proper use and the correctness of the results.”
-% 3.	THE PROGRAM IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR 
-%       A PARTICULAR PURPOSE AND NONINFRINGEMENT OF ANY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS. IN NO EVENT SHALL THE LICENSOR, THE AUTHORS OR THE COPYRIGHT 
-%       HOLDERS BE LIABLE FOR ANY CLAIM, DIRECT, INDIRECT OR CONSEQUENTIAL DAMAGES OR OTHER LIABILITY ARISING FROM, OUT OF OR IN CONNECTION WITH THE PROGRAM OR THE USE 
-%       OF THE PROGRAM OR OTHER DEALINGS IN THE PROGRAM.
-% 4.	LICENSEE agrees that it will use the PROGRAM and any modifications, improvements, or derivatives of PROGRAM that LICENSEE may create (collectively, 
-%       "IMPROVEMENTS") solely for academic, non-commercial purposes and that any copy of PROGRAM or derivatives thereof shall be distributed only under the same 
-%       license as PROGRAM. The terms "academic, non-commercial", as used in this Agreement, mean academic or other scholarly research which (a) is not undertaken for 
-%       profit, or (b) is not intended to produce works, services, or data for commercial use, or (c) is neither conducted, nor funded, by a person or an entity engaged 
-%       in the commercial use, application or exploitation of works similar to the PROGRAM.
-% 5.	LICENSEE agrees that it shall make the following acknowledgement in any publication resulting from the use of the PROGRAM or any translation of the code into 
-%       another computing language:
-%       "Data processing was carried out using the cSAXS ptychography MATLAB package developed by the Science IT and the coherent X-ray scattering (CXS) groups, Paul 
-%       Scherrer Institut, Switzerland."
-% 
-% Additionally, any publication using the package, or any translation of the code into another computing language should cite for difference map:
-% P. Thibault, M. Dierolf, A. Menzel, O. Bunk, C. David, F. Pfeiffer, High-resolution scanning X-ray diffraction microscopy, Science 321, 379–382 (2008). 
-%   (doi: 10.1126/science.1158573),
-% for mixed coherent modes:
-% P. Thibault and A. Menzel, Reconstructing state mixtures from diffraction measurements, Nature 494, 68–71 (2013). (doi: 10.1038/nature11806),
-% for LSQ-ML method 
-% M. Odstrcil, A. Menzel, M.G. Sicairos,  Iterative least-squares solver for generalized maximum-likelihood ptychography, Optics Express, 2018
-% for OPRP method 
-%  M. Odstrcil, P. Baksh, S. A. Boden, R. Card, J. E. Chad, J. G. Frey, W. S. Brocklesby,  "Ptychographic coherent diffractive imaging with orthogonal probe relaxation." Optics express 24.8 (2016): 8360-8369
-% and/or for multislice:
-% E. H. R. Tsai, I. Usov, A. Diaz, A. Menzel, and M. Guizar-Sicairos, X-ray ptychography with extended depth of field, Opt. Express 24, 29089–29108 (2016). 
-% 6.	Except for the above-mentioned acknowledgment, LICENSEE shall not use the PROGRAM title or the names or logos of LICENSOR, nor any adaptation thereof, nor the 
-%       names of any of its employees or laboratories, in any advertising, promotional or sales material without prior written consent obtained from LICENSOR in each case.
-% 7.	Ownership of all rights, including copyright in the PROGRAM and in any material associated therewith, shall at all times remain with LICENSOR, and LICENSEE 
-%       agrees to preserve same. LICENSEE agrees not to use any portion of the PROGRAM or of any IMPROVEMENTS in any machine-readable form outside the PROGRAM, nor to 
-%       make any copies except for its internal use, without prior written consent of LICENSOR. LICENSEE agrees to place the following copyright notice on any such copies: 
-%       © All rights reserved. PAUL SCHERRER INSTITUT, Switzerland, Laboratory for Macromolecules and Bioimaging, 2017. 
-% 8.	The LICENSE shall not be construed to confer any rights upon LICENSEE by implication or otherwise except as specifically set forth herein.
-% 9.	DISCLAIMER: LICENSEE shall be aware that Phase Focus Limited of Sheffield, UK has an international portfolio of patents and pending applications which relate 
-%       to ptychography and that the PROGRAM may be capable of being used in circumstances which may fall within the claims of one or more of the Phase Focus patents, 
-%       in particular of patent with international application number PCT/GB2005/001464. The LICENSOR explicitly declares not to indemnify the users of the software 
-%       in case Phase Focus or any other third party will open a legal action against the LICENSEE due to the use of the program.
-% 10.	This Agreement shall be governed by the material laws of Switzerland and any dispute arising out of this Agreement or use of the PROGRAM shall be brought before 
-%       the courts of Zürich, Switzerland. 
-% 
-%       
-
 function [aPsi, aPsi2, cache, self] = get_reciprocal_model(self, Psi, modF, mask,iter, g_ind, par, cache)
     import engines.GPU.GPU_wrapper.*
     aPsi2 = [];
@@ -190,7 +132,12 @@ function [aPsi2, cache, self] = get_linear_correction_model(self,par,cache,aPsi2
                 aPsi2 = aPsi2(cache.fftshift_idx{:},:);
             end
 
-            % apply blur correction 
+            % apply blur correction. ZC's version
+            if self.diff_pattern_blur > 0
+                blur_kernel = fspecial('gaussian', round(self.diff_pattern_blur)*10+1, self.diff_pattern_blur);
+                aPsi2 = convn(aPsi2, blur_kernel, 'same');  
+            end
+            %{
             if self.diff_pattern_blur > 0
                 % generate blurring kernel 
                 x = [-1, 0,-1]/self.diff_pattern_blur;
@@ -199,7 +146,7 @@ function [aPsi2, cache, self] = get_linear_correction_model(self,par,cache,aPsi2
                 blur_kernel  = blur_kernel  / math.sum2( blur_kernel ); 
                 aPsi2 = convn(aPsi2, blur_kernel, 'same');  
             end
-
+            %}
             if isempty(self.modes{1}.ASM_factor)  % is not nearfield
                 aPsi2 = aPsi2(cache.fftshift_idx{:},:);
             end
@@ -250,8 +197,3 @@ function [nom, denom] = get_background_estimate(modF, aPsi2, mask, distribution,
        nom =  W.* (modF.^2 - aPsi2).*background; 
        denom = W.*background.^2;
 end
-
-
-
-
-

--- a/ptycho/+engines/+GPU_MS/+initialize/load_from_p.m
+++ b/ptycho/+engines/+GPU_MS/+initialize/load_from_p.m
@@ -421,8 +421,15 @@ function [self, param, p] = load_from_p(param, p)
     end
     
     self.lambda = p.lambda;
-    self.diff_pattern_blur = 0;  % incoherent smoothing 
-    self.modes = []; 
+
+    if check_option(p,'diff_pattern_blur') && p.diff_pattern_blur > 0
+        verbose(0, 'Account for detector blur with a Gaussian kernel (sigma=%0.1f)', p.diff_pattern_blur)
+        self.diff_pattern_blur = p.diff_pattern_blur;
+    else
+        self.diff_pattern_blur = 0;  % incoherent smoothing 
+    end
+    
+    self.modes = [];
            
     % keep p structure for plotting purposes 
     param.p = p;
@@ -461,3 +468,4 @@ function [self, param, p] = load_from_p(param, p)
 
     
 end
+

--- a/ptycho/+engines/+GPU_MS/private/get_reciprocal_model.m
+++ b/ptycho/+engines/+GPU_MS/private/get_reciprocal_model.m
@@ -17,64 +17,6 @@
 % ++ cache          structure with precalculated values 
 % ++ self           structure containing inputs: e.g. current reconstruction results, data, mask, positions, pixel size, ..
 
-
-
-% Academic License Agreement
-% 
-% Source Code
-% 
-% Introduction 
-% •	This license agreement sets forth the terms and conditions under which the PAUL SCHERRER INSTITUT (PSI), CH-5232 Villigen-PSI, Switzerland (hereafter "LICENSOR") 
-%   will grant you (hereafter "LICENSEE") a royalty-free, non-exclusive license for academic, non-commercial purposes only (hereafter "LICENSE") to use the cSAXS 
-%   ptychography MATLAB package computer software program and associated documentation furnished hereunder (hereafter "PROGRAM").
-% 
-% Terms and Conditions of the LICENSE
-% 1.	LICENSOR grants to LICENSEE a royalty-free, non-exclusive license to use the PROGRAM for academic, non-commercial purposes, upon the terms and conditions 
-%       hereinafter set out and until termination of this license as set forth below.
-% 2.	LICENSEE acknowledges that the PROGRAM is a research tool still in the development stage. The PROGRAM is provided without any related services, improvements 
-%       or warranties from LICENSOR and that the LICENSE is entered into in order to enable others to utilize the PROGRAM in their academic activities. It is the 
-%       LICENSEE’s responsibility to ensure its proper use and the correctness of the results.”
-% 3.	THE PROGRAM IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR 
-%       A PARTICULAR PURPOSE AND NONINFRINGEMENT OF ANY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS. IN NO EVENT SHALL THE LICENSOR, THE AUTHORS OR THE COPYRIGHT 
-%       HOLDERS BE LIABLE FOR ANY CLAIM, DIRECT, INDIRECT OR CONSEQUENTIAL DAMAGES OR OTHER LIABILITY ARISING FROM, OUT OF OR IN CONNECTION WITH THE PROGRAM OR THE USE 
-%       OF THE PROGRAM OR OTHER DEALINGS IN THE PROGRAM.
-% 4.	LICENSEE agrees that it will use the PROGRAM and any modifications, improvements, or derivatives of PROGRAM that LICENSEE may create (collectively, 
-%       "IMPROVEMENTS") solely for academic, non-commercial purposes and that any copy of PROGRAM or derivatives thereof shall be distributed only under the same 
-%       license as PROGRAM. The terms "academic, non-commercial", as used in this Agreement, mean academic or other scholarly research which (a) is not undertaken for 
-%       profit, or (b) is not intended to produce works, services, or data for commercial use, or (c) is neither conducted, nor funded, by a person or an entity engaged 
-%       in the commercial use, application or exploitation of works similar to the PROGRAM.
-% 5.	LICENSEE agrees that it shall make the following acknowledgement in any publication resulting from the use of the PROGRAM or any translation of the code into 
-%       another computing language:
-%       "Data processing was carried out using the cSAXS ptychography MATLAB package developed by the Science IT and the coherent X-ray scattering (CXS) groups, Paul 
-%       Scherrer Institut, Switzerland."
-% 
-% Additionally, any publication using the package, or any translation of the code into another computing language should cite for difference map:
-% P. Thibault, M. Dierolf, A. Menzel, O. Bunk, C. David, F. Pfeiffer, High-resolution scanning X-ray diffraction microscopy, Science 321, 379–382 (2008). 
-%   (doi: 10.1126/science.1158573),
-% for mixed coherent modes:
-% P. Thibault and A. Menzel, Reconstructing state mixtures from diffraction measurements, Nature 494, 68–71 (2013). (doi: 10.1038/nature11806),
-% for LSQ-ML method 
-% M. Odstrcil, A. Menzel, M.G. Sicairos,  Iterative least-squares solver for generalized maximum-likelihood ptychography, Optics Express, 2018
-% for OPRP method 
-%  M. Odstrcil, P. Baksh, S. A. Boden, R. Card, J. E. Chad, J. G. Frey, W. S. Brocklesby,  "Ptychographic coherent diffractive imaging with orthogonal probe relaxation." Optics express 24.8 (2016): 8360-8369
-% and/or for multislice:
-% E. H. R. Tsai, I. Usov, A. Diaz, A. Menzel, and M. Guizar-Sicairos, X-ray ptychography with extended depth of field, Opt. Express 24, 29089–29108 (2016). 
-% 6.	Except for the above-mentioned acknowledgment, LICENSEE shall not use the PROGRAM title or the names or logos of LICENSOR, nor any adaptation thereof, nor the 
-%       names of any of its employees or laboratories, in any advertising, promotional or sales material without prior written consent obtained from LICENSOR in each case.
-% 7.	Ownership of all rights, including copyright in the PROGRAM and in any material associated therewith, shall at all times remain with LICENSOR, and LICENSEE 
-%       agrees to preserve same. LICENSEE agrees not to use any portion of the PROGRAM or of any IMPROVEMENTS in any machine-readable form outside the PROGRAM, nor to 
-%       make any copies except for its internal use, without prior written consent of LICENSOR. LICENSEE agrees to place the following copyright notice on any such copies: 
-%       © All rights reserved. PAUL SCHERRER INSTITUT, Switzerland, Laboratory for Macromolecules and Bioimaging, 2017. 
-% 8.	The LICENSE shall not be construed to confer any rights upon LICENSEE by implication or otherwise except as specifically set forth herein.
-% 9.	DISCLAIMER: LICENSEE shall be aware that Phase Focus Limited of Sheffield, UK has an international portfolio of patents and pending applications which relate 
-%       to ptychography and that the PROGRAM may be capable of being used in circumstances which may fall within the claims of one or more of the Phase Focus patents, 
-%       in particular of patent with international application number PCT/GB2005/001464. The LICENSOR explicitly declares not to indemnify the users of the software 
-%       in case Phase Focus or any other third party will open a legal action against the LICENSEE due to the use of the program.
-% 10.	This Agreement shall be governed by the material laws of Switzerland and any dispute arising out of this Agreement or use of the PROGRAM shall be brought before 
-%       the courts of Zürich, Switzerland. 
-% 
-%       
-
 function [aPsi, aPsi2, cache, self] = get_reciprocal_model(self, Psi, modF, mask,iter, g_ind, par, cache)
     import engines.GPU_MS.GPU_wrapper.*
     aPsi2 = [];
@@ -215,16 +157,21 @@ function [aPsi2, cache, self] = get_linear_correction_model(self,par,cache,aPsi2
                 aPsi2 = aPsi2(cache.fftshift_idx{:},:);
             end
 
-            % apply blur correction 
+            % apply blur correction. ZC's version
             if self.diff_pattern_blur > 0
-                % generate blurring kernel 
+                blur_kernel = fspecial('gaussian', round(self.diff_pattern_blur)*10+1, self.diff_pattern_blur);
+                aPsi2 = convn(aPsi2, blur_kernel, 'same');  
+            end
+            %{
+            if self.diff_pattern_blur > 0
+                % generate blurring kernel
                 x = [-1, 0,-1]/self.diff_pattern_blur;
                 [X,Y] = meshgrid(x,x);
                 blur_kernel = exp( -(X.^2 + Y.^2) );
                 blur_kernel  = blur_kernel  / math.sum2( blur_kernel ); 
                 aPsi2 = convn(aPsi2, blur_kernel, 'same');  
             end
-
+            %}
             if isempty(self.modes{1}.ASM_factor)  % is not nearfield
                 aPsi2 = aPsi2(cache.fftshift_idx{:},:);
             end
@@ -275,8 +222,3 @@ function [nom, denom] = get_background_estimate(modF, aPsi2, mask, distribution,
        nom =  W.* (modF.^2 - aPsi2).*background; 
        denom = W.*background.^2;
 end
-
-
-
-
-

--- a/ptycho/utils/generateResultDir.m
+++ b/ptycho/utils/generateResultDir.m
@@ -121,6 +121,10 @@ if ~isempty(param.delta_z)
     end
 end
 
+if isfield(param,'diff_pattern_blur') && param.diff_pattern_blur>0
+    paramInfo = strcat(paramInfo,'_dpBlur',num2str(param.diff_pattern_blur));
+end
+
 if any(param.custom_data_flip)
     paramInfo = strcat(paramInfo,'_dpFlip');
     if param.custom_data_flip(1)==1


### PR DESCRIPTION
Enable the engine variable (eng.diff_pattern_blur) that convolves the exit wave's Fourier intensity with a Gaussian kernel. 
Users can specify the standard deviation of the Gaussian function. Default: eng.diff_pattern_blur = 0 (no blurring).

This feature could be useful for data with partial spatial coherence in the illumination (e.g., https://doi.org/10.1038/srep14690) or finite point spread function in the detector.