### PR TITLE
save probe magnitude in each slice during multislice reconstruction

### DIFF
--- a/ptycho/+engines/+GPU/ptycho_solver.m
+++ b/ptycho/+engines/+GPU/ptycho_solver.m
@@ -660,7 +660,9 @@ while iter <= par.number_iterations %modified by YJ: use while loop for time-res
                 saveName = strcat('obj_phase_roi_Niter',num2str(iter),'.tiff');
                 saveDir = strcat(par.fout,'/obj_phase_roi_stack/');
                 if ~exist(saveDir, 'dir'); mkdir(saveDir); end
-                par_tiff.name = strcat(saveDir,saveName);
+                par_tiff = {};
+                par_tiff.name = strcat(saveDir, saveName);
+                par_tiff.colormap = gray(256);
                 save_tiff_image_stack(O_phase_roi, par_tiff);
             end
         end
@@ -698,7 +700,9 @@ while iter <= par.number_iterations %modified by YJ: use while loop for time-res
                 saveName = strcat('obj_mag_roi_Niter',num2str(iter),'.tiff');
                 saveDir = strcat(par.fout,'/obj_mag_roi_stack/');
                 if ~exist(saveDir, 'dir'); mkdir(saveDir); end
-                par_tiff.name = strcat(saveDir,saveName);
+                par_tiff = {};
+                par_tiff.name = strcat(saveDir, saveName);
+                par_tiff.colormap = gray(256);
                 save_tiff_image_stack(O_mag_roi, par_tiff);
             end
         end

--- a/ptycho/+engines/+GPU_MS/+initialize/get_defaults.m
+++ b/ptycho/+engines/+GPU_MS/+initialize/get_defaults.m
@@ -120,6 +120,7 @@ function [param] = get_defaults
 
     % I/O
     param.save_init_probe = false;       % Added by YJ. If true, save initial probe function in the .mat output file. Default is false.
-    param.save_images = {'obj_ph','obj_ph_sum','obj_ph_stack','probe'}; % Added by YJ. Save intermediate results as tiff images. 
-    % Options: {'obj_ph','obj_ph_sum','obj_ph_stack','obj_mag','obj_ph_sum','obj_mag_stack','probe_mag','probe'}
+    param.save_images = {'obj_ph','obj_ph_sum','obj_ph_stack','probe','probe_mag','probe_prop_mag'}; % Added by YJ. Save intermediate results as tiff images. 
+    % Options: {'obj_ph','obj_ph_sum','obj_ph_stack','obj_mag','obj_ph_sum','obj_mag_stack','probe_mag','probe','probe_prop_mag'}
+
 end

--- a/ptycho/examples/PSO_science/ptycho_electron_PSO_science.m
+++ b/ptycho/examples/PSO_science/ptycho_electron_PSO_science.m
@@ -306,7 +306,7 @@ eng.apply_tilted_plane_correction = ''; % if any(p.sample_rotation_angles([1,2])
 % I/O
 eng.plot_results_every = Niter_plot_results;
 eng.save_results_every = Niter_save_results;
-eng.save_images ={'obj_ph_stack','obj_ph_sum','probe'};
+eng.save_images ={'obj_ph_stack','obj_ph_sum','probe','probe_mag','probe_prop_mag'};
 eng.extraPrintInfo = strcat('PSO');
 
 resultDir = strcat(p.base_path,sprintf(p.scan.format, p.scan_number),'/roi',p.scan.roi_label,'/');


### PR DESCRIPTION
Added a new option ('probe_prop_mag') for the eng.save_images variable. When included, a tiff stack that stores probe magnitude in each slice (assuming free-space propagation) is saved during multislice reconstruction. 

The feature is identical to #120. It could be useful for diagnosing probe structure in multislice ptychography.