### PR TITLE
increase the default size limit for EMPAD

### DIFF
--- a/ptycho/+detector/+empad/empad.m
+++ b/ptycho/+detector/+empad/empad.m
@@ -1,5 +1,5 @@
-%EIGER settings for Eiger detector
-%   This file is called if you specify p.detector = 'eiger_APS'.
+%Settings for EMPAD detector
+%   This file is called if you specify p.detector = 'empad'.
 % ** p          p structure
 % returns:
 % ++ det        detector structure; later accessible via p.detectors(ii).params
@@ -20,8 +20,7 @@ det.basepath_dir = 'eiger/';            % raw data directory
 det.mask_saturated_value = [];          % mask pixels above given value
 det.mask_below_value = [];              % mask pixels below given value
 det.data_stored = true;                % false == data are generated "onfly", no need to load / store
-%det.geometry.sz = [1030 514];           % detector readout size
-det.geometry.sz = [256 256];           % detector readout size
+det.geometry.sz = [1024 1024];           % detector readout size
 
 det.geometry.mask = [];                 % if the mask is larger than the readout 
                                         % geometry (det.geometry.sz), geometry.mask defines the readout for the mask


### PR DESCRIPTION
Increase the default size limit of EMPAD to 1024 in preparation for next-generation detectors.