### PR TITLE
Fix add_momentum_probe.m for LSQML when using MLc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+ptycho/+engines/+GPU/+LSQML/private/get_LSQ_step_mex.mexw64
+ptycho/+engines/+GPU/+shared/private/get_views_gpu_mex.mexw64
+ptycho/+engines/+GPU/+shared/private/set_views_gpu_mex.mexw64

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-ptycho/+engines/+GPU/+LSQML/private/get_LSQ_step_mex.mexw64
-ptycho/+engines/+GPU/+shared/private/get_views_gpu_mex.mexw64
-ptycho/+engines/+GPU/+shared/private/set_views_gpu_mex.mexw64

--- a/ptycho/+engines/+GPU/+LSQML/add_momentum_probe.m
+++ b/ptycho/+engines/+GPU/+LSQML/add_momentum_probe.m
@@ -83,7 +83,6 @@ function [self, cache] = add_momentum_probe(self, cache, par, probe_upd, iter, f
 
    verbose(1, 'Adding momentum to probe')
 
-   %disp(size(self.probe))
        
    Nmodes = size(self.probe,1);
 
@@ -131,12 +130,10 @@ function [self, cache] = add_momentum_probe(self, cache, par, probe_upd, iter, f
                         
             if all(corr_level(:) > 0 ) && ferr_ok
 
-try
+
                 % estimate optimal friction from previous steps 
                 poly_fit = polyfit(repmat(0:momentum_memory,probe_modes,1),[zeros(1,probe_modes);log(corr_level)]',1); 
-catch
-    keyboard
-end
+
                 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
                 gain = par.momentum;                           % smaller -> lower relative speed (less momentum)
                 friction =  0.5*max(-poly_fit(1),0);   % smaller -> longer memory, more momentum 

--- a/ptycho/+engines/+GPU_MS/+LSQML/add_momentum_probe.m
+++ b/ptycho/+engines/+GPU_MS/+LSQML/add_momentum_probe.m
@@ -128,12 +128,9 @@ function [self, cache] = add_momentum_probe(self, cache, par, probe_upd, iter, f
                         
             if all(corr_level(:) > 0 ) && ferr_ok
 
-try
                 % estimate optimal friction from previous steps 
                 poly_fit = polyfit(repmat(0:momentum_memory,probe_modes,1),[zeros(1,probe_modes);log(corr_level)]',1); 
-catch
-    keyboard
-end
+                
                 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
                 gain = par.momentum;                           % smaller -> lower relative speed (less momentum)
                 friction =  0.5*max(-poly_fit(1),0);   % smaller -> longer memory, more momentum 


### PR DESCRIPTION
There're erroneous lines of try-catch block with incorrect indentation in `add_momentum_probe.m` that prevents `polyfit` from being executing.