### PR TITLE
propagate initial probe for electron ptychography

### DIFF
--- a/ptycho/+core/ptycho_model_probe.m
+++ b/ptycho/+core/ptycho_model_probe.m
@@ -58,15 +58,15 @@ if p.model_probe
         end
         %twofold astigmatism in angstrom & azimuthal orientation in radian
         if isfield(p.model,'probe_f_a2') && isfield(p.model,'probe_theta_a2') && p.model.probe_f_a2~=0
-        	chi = chi + pi*p.model.probe_f_a2*lambda*kR.^2*sin(2*(theta-p.model.probe_theta_a2));
+        	chi = chi + pi*p.model.probe_f_a2*lambda*kR.^2.*sin(2*(theta-p.model.probe_theta_a2));
         end
         %threefold astigmatism in angstrom & azimuthal orientation in radian
         if isfield(p.model,'probe_f_a3') && isfield(p.model,'probe_theta_a3') && p.model.probe_f_a3~=0
-        	chi = chi + 2*pi/3*p.model.probe_f_a3*lambda^2*kR.^3*sin(3*(theta-p.model.probe_theta_a3));
+        	chi = chi + 2*pi/3*p.model.probe_f_a3*lambda^2*kR.^3.*sin(3*(theta-p.model.probe_theta_a3));
         end
         %coma in angstrom & azimuthal orientation in radian
         if isfield(p.model,'probe_f_c3') && isfield(p.model,'probe_theta_c3') && p.model.probe_f_c3~=0
-        	chi = chi + 2*pi/3*p.model.probe_f_c3*lambda^2*kR.^3*sin(theta-p.model.probe_theta_c3);
+        	chi = chi + 2*pi/3*p.model.probe_f_c3*lambda^2*kR.^3.*sin(theta-p.model.probe_theta_c3);
         end
         
         probe = mask.*exp(-1i.*chi);
@@ -217,8 +217,13 @@ else
         end
     end
     if ~isempty(p.probe_file_propagation) && any(p.probe_file_propagation ~= 0)
-        verbose(2,'Propagating probe from file by %f mm',p.probe_file_propagation*1e3);
-        probe= prop_free_nf(double(probe), lambda, p.probe_file_propagation, dx_spec);
+        if isfield(p,'beam_source') && strcmp(p.beam_source, 'electron')
+            verbose(2,'Propagating probe from file by %f nm',p.probe_file_propagation/10);
+            probe= prop_free_nf(double(probe), lambda, -p.probe_file_propagation, dx_spec); %flip the sign for consistency
+        else
+            verbose(2,'Propagating probe from file by %f mm',p.probe_file_propagation*1e3);
+            probe= prop_free_nf(double(probe), lambda, p.probe_file_propagation, dx_spec);
+        end
     end
 
 end
@@ -231,3 +236,4 @@ else
 end
 pout = p;
 pout.probe_initial = probe;
+

--- a/ptycho/examples/MoSe2_nat_comm/ptycho_electron_MoSe2_nature_comm.m
+++ b/ptycho/examples/MoSe2_nat_comm/ptycho_electron_MoSe2_nature_comm.m
@@ -138,17 +138,17 @@ p.   initial_iterate_object_file{1} = '';                   %  use this mat-file
 
 % Initial iterate probe
 p.   model_probe = false;                                   % Use model probe, if false load it from file 
-p.   model.probe_alpha_max = 21.4;                          % Modal STEM probe's aperture size
-p.   model.probe_df = -500;                                 % Modal STEM probe's defocus
-p.   model.probe_c3 = 0;                                    % Modal STEM probe's third-order spherical aberration in angstrom (optional)
-p.   model.probe_c5 = 0;                                    % Modal STEM probe's fifth-order spherical aberration in angstrom (optional)
-p.   model.probe_c7 = 0;                                    % Modal STEM probe's seventh-order spherical aberration in angstrom (optional)
-p.   model.probe_f_a2 = 0;                                  % Modal STEM probe's twofold astigmatism in angstrom (optional)
-p.   model.probe_theta_a2 = 0;                              % Modal STEM probe's twofold azimuthal orientation in radian (optional)
-p.   model.probe_f_a3 = 0;                                  % Modal STEM probe's threefold astigmatism in angstrom (optional)
-p.   model.probe_theta_a3 = 0;                              % Modal STEM probe's threefold azimuthal orientation in radian (optional)
-p.   model.probe_f_c3 = 0;                                  % Modal STEM probe's coma in angstrom (optional)
-p.   model.probe_theta_c3 = 0;                              % Modal STEM probe's coma azimuthal orientation in radian (optional)
+p.   model.probe_alpha_max = 21.4;                          % Model STEM probe's aperture size
+p.   model.probe_df = -500;                                 % Model STEM probe's defocus
+p.   model.probe_c3 = 0;                                    % Model STEM probe's third-order spherical aberration in angstrom (optional)
+p.   model.probe_c5 = 0;                                    % Model STEM probe's fifth-order spherical aberration in angstrom (optional)
+p.   model.probe_c7 = 0;                                    % Model STEM probe's seventh-order spherical aberration in angstrom (optional)
+p.   model.probe_f_a2 = 0;                                  % Model STEM probe's twofold astigmatism in angstrom (optional)
+p.   model.probe_theta_a2 = 0;                              % Model STEM probe's twofold azimuthal orientation in radian (optional)
+p.   model.probe_f_a3 = 0;                                  % Model STEM probe's threefold astigmatism in angstrom (optional)
+p.   model.probe_theta_a3 = 0;                              % Model STEM probe's threefold azimuthal orientation in radian (optional)
+p.   model.probe_f_c3 = 0;                                  % Model STEM probe's coma in angstrom (optional)
+p.   model.probe_theta_c3 = 0;                              % Model STEM probe's coma azimuthal orientation in radian (optional)
 
 %Use probe from this mat-file (not used if model_probe is true)
 p.   initial_probe_file = initial_probe_file;

--- a/ptycho/examples/PSO_science/ptycho_electron_PSO_science.m
+++ b/ptycho/examples/PSO_science/ptycho_electron_PSO_science.m
@@ -137,17 +137,17 @@ p.   initial_iterate_object_file{1} = '';                   %  use this mat-file
 
 % Initial iterate probe
 p.   model_probe = false;                                   % Use model probe, if false load it from file 
-p.   model.probe_alpha_max = 21.4;                          % Modal STEM probe's aperture size
-p.   model.probe_df = -200;                                 % Modal STEM probe's defocus
-p.   model.probe_c3 = 0;                                    % Modal STEM probe's third-order spherical aberration in angstrom (optional)
-p.   model.probe_c5 = 0;                                    % Modal STEM probe's fifth-order spherical aberration in angstrom (optional)
-p.   model.probe_c7 = 0;                                    % Modal STEM probe's seventh-order spherical aberration in angstrom (optional)
-p.   model.probe_f_a2 = 0;                                  % Modal STEM probe's twofold astigmatism in angstrom (optional)
-p.   model.probe_theta_a2 = 0;                              % Modal STEM probe's twofold azimuthal orientation in radian (optional)
-p.   model.probe_f_a3 = 0;                                  % Modal STEM probe's threefold astigmatism in angstrom (optional)
-p.   model.probe_theta_a3 = 0;                              % Modal STEM probe's threefold azimuthal orientation in radian (optional)
-p.   model.probe_f_c3 = 0;                                  % Modal STEM probe's coma in angstrom (optional)
-p.   model.probe_theta_c3 = 0;                              % Modal STEM probe's coma azimuthal orientation in radian (optional)
+p.   model.probe_alpha_max = 21.4;                          % Model STEM probe's aperture size
+p.   model.probe_df = -200;                                 % Model STEM probe's defocus
+p.   model.probe_c3 = 0;                                    % Model STEM probe's third-order spherical aberration in angstrom (optional)
+p.   model.probe_c5 = 0;                                    % Model STEM probe's fifth-order spherical aberration in angstrom (optional)
+p.   model.probe_c7 = 0;                                    % Model STEM probe's seventh-order spherical aberration in angstrom (optional)
+p.   model.probe_f_a2 = 0;                                  % Model STEM probe's twofold astigmatism in angstrom (optional)
+p.   model.probe_theta_a2 = 0;                              % Model STEM probe's twofold azimuthal orientation in radian (optional)
+p.   model.probe_f_a3 = 0;                                  % Model STEM probe's threefold astigmatism in angstrom (optional)
+p.   model.probe_theta_a3 = 0;                              % Model STEM probe's threefold azimuthal orientation in radian (optional)
+p.   model.probe_f_c3 = 0;                                  % Model STEM probe's coma in angstrom (optional)
+p.   model.probe_theta_c3 = 0;                              % Model STEM probe's coma azimuthal orientation in radian (optional)
 
 %Use probe from this mat-file (not used if model_probe is true)
 p.   initial_probe_file = initial_probe_file;


### PR DESCRIPTION
This PR allows users to correctly propagate the initial probe (from a file) before ptychographic reconstruction. 
Also fixed some bugs (#112 ) and typos related to the model STEM probe. 