### PR TITLE
add example scripts for using Bayesian optimization to calibrate experimental parameters in electron ptychography

### DIFF
--- a/ptycho/examples/MoSe2_nat_comm/bo_calibrate_exp_params_MoSe2_nature_comm.m
+++ b/ptycho/examples/MoSe2_nat_comm/bo_calibrate_exp_params_MoSe2_nature_comm.m
@@ -1,0 +1,91 @@
+%clear variables
+addpath(strcat(pwd,'/utils/'))
+addpath(core.find_base_package)
+utils.ccc
+%% Step 0: Run the prepare_data script to generate data for ptycho reconstruction
+%% Step 1: Prepare data and reconstruction parameters
+par = {};
+par.verbose_level = 2;
+par.scan_number = 1;
+par.beam_source = 'electron';
+
+par.Ndp = 128;
+par.base_path = '/home/beams2/YJIANG/ptychography/electron/mose2/nat_comm/';
+
+par.scan_format = 'scan%d';
+par.scan_string_format = 'scan%d';
+par.roi_label = '0_Ndp128';
+
+par.cen_dp_y = floor(par.Ndp/2)+1;
+par.cen_dp_x = floor(par.Ndp/2)+1;
+
+par.energy = 80;
+par.dk = 0.0197;
+
+par.scan_nx = 60;
+par.scan_ny = 60;
+
+par.scan_step_size_x = 0.85;
+par.scan_step_size_y = 0.85;
+
+par.scan_custom_fliplr = 1;
+par.scan_custom_flipud = 1;
+par.scan_custom_transpose = 1;
+
+par.detector_name = 'empad';
+par.data_preparator = 'matlab_aps';
+par.src_positions =  'matlab_pos';
+par.scan_type = 'raster';
+
+par.use_model_probe = true;
+par.normalize_init_probe = true;
+
+par.output_dir_base = par.base_path;
+par.Niter = 20;
+par.Niter_save_results_every =  par.Niter;
+
+par.eng_name = 'GPU';
+par.method = 'MLs';
+par.momentum = 0;
+
+par.Nprobe = 2;
+par.grouping = 90;
+par.apply_multimodal_update = true;
+
+%% Step 1.5 (optional): Run a single reconstruction to check parameters
+GPU_list = 1;
+defocus = -450;
+rot_ang = 30;
+alpha = 21.4;
+thickness = 0; %single-slice ptycho
+data_error = ptycho_recon_exp_data_electron(par, defocus, alpha, rot_ang, thickness, GPU_list);
+
+%% Step 2: Use Bayesian optimization with Gaussian processes to find experimental parameters that minimize data error 
+close all
+rot_ang = 30;
+%rot_ang = optimizableVariable('rot_ang',[-90, 90]); %degrees 
+alpha = 21.4;
+defocus = optimizableVariable('defocus',[-1000, 1000]); %angstroms
+%defocus = -550;
+GPU_list = [1];
+thickness = 0; %single-slice ptycho
+
+N_workers = length(GPU_list);
+if N_workers>1
+    delete(gcp('nocreate'))
+    c = parcluster('local');
+    c.NumWorkers = N_workers;
+    p = parpool(c);
+end
+
+fun = @(x)ptycho_recon_exp_data_electron(par, x.defocus, alpha, rot_ang, thickness, GPU_list);
+results = bayesopt(fun, [defocus],...
+    'Verbose',2,...
+    'AcquisitionFunctionName','expected-improvement-plus',...
+    'IsObjectiveDeterministic',false,...
+    'MaxObjectiveEvaluations', 30,...
+    'NumSeedPoints',N_workers,...
+    'PlotFcn',{@plotObjectiveModel, @plotMinObjective},'UseParallel', N_workers>1);
+
+delete(gcp('nocreate'))
+

--- a/ptycho/examples/PSO_science/bo_calibrate_exp_params_PSO_science.m
+++ b/ptycho/examples/PSO_science/bo_calibrate_exp_params_PSO_science.m
@@ -1,0 +1,97 @@
+%clear variables
+addpath(strcat(pwd,'/utils/'))
+addpath(core.find_base_package)
+utils.ccc
+%% Step 0: Run the prepare_data script to generate data for ptycho reconstruction
+%% Step 1: Prepare data and reconstruction parameters
+par = {};
+par.verbose_level = 2;
+par.scan_number = 1;
+par.beam_source = 'electron';
+
+par.Ndp = 256;
+par.base_path = '/home/beams2/YJIANG/ptychography/electron/PrScO3/science/';
+
+par.scan_format = '%01d';
+par.scan_string_format = '%01d';
+par.roi_label = '0_Ndp256';
+
+par.cen_dp_y = floor(par.Ndp/2)+1;
+par.cen_dp_x = floor(par.Ndp/2)+1;
+
+par.energy = 300;
+par.rbf = 26;
+
+par.scan_nx = 64;
+par.scan_ny = 64;
+
+par.scan_step_size_x = 0.41;
+par.scan_step_size_y = 0.41;
+
+par.scan_custom_fliplr = 1;
+par.scan_custom_flipud = 1;
+par.scan_custom_transpose = 1;
+
+par.detector_name = 'empad';
+par.data_preparator = 'matlab_aps';
+par.src_positions =  'matlab_pos';
+par.scan_type = 'raster';
+
+par.use_model_probe = true;
+par.normalize_init_probe = true;
+
+par.output_dir_base = par.base_path;
+par.Niter = 20;
+par.Niter_save_results_every =  par.Niter;
+
+par.eng_name = 'GPU_MS';
+par.method = 'MLs';
+par.momentum = 0;
+
+par.Nprobe = 8;
+par.grouping = 128;
+par.apply_multimodal_update = false;
+
+par.Nlayers = 10;
+par.regularize_layers = 1;
+par.variable_probe_modes = 1;
+par.Ndp_presolve = 128;
+
+%% Step 1.5 (optional): Run a single reconstruction to check parameters
+GPU_list = 1;
+defocus = -200;
+rot_ang = 0;
+alpha = 21.4;
+thickness = 210; %in angstroms
+data_error = ptycho_recon_exp_data_electron(par, defocus, alpha, rot_ang, thickness, GPU_list);
+
+%% Step 2: Use Bayesian optimization with Gaussian processes to find experimental parameters that minimize data error
+% Note: Parallel BO is generally recommended for multislice reconstructions
+close all
+rot_ang = 0;
+alpha = 21.4;
+defocus = optimizableVariable('defocus',[-1000, 1000]); %angstroms
+%defocus = -200;
+GPU_list = [1,2,3,4,5,6,7,8,9,10];
+%thickness = 210; %angstroms
+thickness = optimizableVariable('thickness',[100, 300]); %angstroms
+
+N_workers = length(GPU_list);
+if N_workers>1
+    delete(gcp('nocreate'))
+    c = parcluster('local');
+    c.NumWorkers = N_workers;
+    p = parpool(c);
+end
+
+fun = @(x)ptycho_recon_exp_data_electron(par, x.defocus, alpha, rot_ang, x.thickness, GPU_list);
+results = bayesopt(fun, [defocus, thickness],...
+    'Verbose',2,...
+    'AcquisitionFunctionName','expected-improvement-plus',...
+    'IsObjectiveDeterministic',false,...
+    'MaxObjectiveEvaluations', 50,...
+    'NumSeedPoints',N_workers,...
+    'PlotFcn',{@plotObjectiveModel, @plotMinObjective},'UseParallel', N_workers>1);
+
+delete(gcp('nocreate'))
+

--- a/ptycho/ptycho_recon_exp_data_electron.m
+++ b/ptycho/ptycho_recon_exp_data_electron.m
@@ -1,0 +1,55 @@
+% Wrapper function for reconstructing experimental electron ptychography data
+% Can be used with BO-GP to tune experimental parameters
+% Written by Yi Jiang
+%
+% Inputs:
+% ** par       - structure containting data and reonstruction parameters
+% ** defocus   - probe defocus (in angstroms)
+% ** alpha     - aperture size (in mrad)
+% ** rot_ang   - in-plane rotation between diffraction patterns and scan cor
+% ** thickness - total sample thickness (in angstroms). Effective in multislice recon only
+% ** GPU_list  - list of GPU ids. Assumes multiple workers if length(GPU_list) > 1
+%
+% Output:
+%  ++ data_error - averaged data error of last iteration
+
+function [data_error] = ptycho_recon_exp_data_electron(par, defocus, alpha, rot_ang, thickness, GPU_list)
+
+if length(GPU_list)>1
+    t = getCurrentTask;
+    t = t.ID;
+    gpu_id = GPU_list(t);
+else
+    gpu_id = GPU_list;
+end
+
+par_recon = par;
+par_recon.gpu_id = gpu_id; 
+
+if ~isfield(par, 'dk') || par_recon.dk<0
+    par_recon.d_alpha = alpha/par.rbf; %use rbf to calculate pixel size of diffraction patterns
+end
+
+affine_mat  = compose_affine_matrix(1, 0, rot_ang, 0);
+par_recon.affine_matrix_11 = affine_mat(1,1);
+par_recon.affine_matrix_12 = affine_mat(1,2);
+par_recon.affine_matrix_21 = affine_mat(2,1);
+par_recon.affine_matrix_22 = affine_mat(2,2);
+
+if par_recon.use_model_probe
+    par_recon.probe_alpha_max = alpha;
+    par_recon.probe_df = defocus;
+end
+
+par_recon.output_dir_suffix = sprintf('_alpha%0.2f_df%0.2f_rot_ang%0.1f', alpha, defocus, rot_ang);
+
+if strcmp(par_recon.eng_name, 'GPU_MS') && thickness > 0
+    par_recon.delta_z = thickness / par_recon.Nlayers;
+    par_recon.output_dir_suffix = strcat(par_recon.output_dir_suffix, sprintf('_thickness%0.1f', thickness));
+end
+
+[~, ~, data_error] = ptycho_recon(par_recon);
+
+end
+
+


### PR DESCRIPTION
Add two example scripts to demonstrate how Bayesian optimization with Gaussian processes finds the experimental parameters that minimize data error after reconstructions.

- Both examples utilize a wrapper function (ptycho_recon_exp_data_electron) that carries out ptychographic reconstructions based on user-speficied experimental parameters.
- Parallel BO is highly recommended, especially for multislice reconstructions due to their long computational time.
- As an example, here is a BO run for tuning probe defocus and sample thickness of the PSO data.
<img width="1694" alt="Screenshot 2023-10-29 at 2 29 33 PM" src="https://github.com/yijiang1/fold_slice/assets/13088588/46453910-59b9-450c-b9c2-3e344df36dcd">
- For more examples of Bayesian optimization in ptychography, see https://doi.org/10.1038/s41598-022-16041-5

