### PR TITLE
add wrapper functions that simulate electron ptychography data and evaluate its reconstruction quality

### DIFF
--- a/ptycho/sim_electron_cbed.m
+++ b/ptycho/sim_electron_cbed.m
@@ -1,0 +1,209 @@
+% Wrapper function for simulating diffraction patterns for electron ptychography 
+% Results are saved in formats required by reconstruction scripts
+% Assumes the strong phase approximation model only
+%
+% input:
+% ** param structure containting experimental conditions and probe parameters
+
+% returns:
+% dp                 simulated diffraction patterns
+% probe_true         simulated probe
+% p                  p structure corresponding saved probe function
+
+function [dp, probe_true, p] = sim_electron_cbed(param)
+
+    addpath(strcat(pwd,'/utils_electron/'))
+    addpath(core.find_base_package)
+
+    % parse inputs
+    parse_param = inputParser;
+    parse_param.KeepUnmatched = true;
+    
+    % parameters
+    parse_param.addParameter('output_path', '', @ischar)
+
+    parse_param.addParameter('field_of_view', 36, @isnumeric) %scan FOV in angstroms
+    parse_param.addParameter('N_dp', 256, @isnumeric) %size of diffraction pattern in pixels 
+    parse_param.addParameter('N_dp_orig', 256, @isnumeric) %original size of diffraction pattern in pixels
+    parse_param.addParameter('scan_step_size', 2, @isnumeric) %scan step size in angstroms
+    parse_param.addParameter('max_position_error', 0, @isnumeric) %max random position error in angstroms
+    parse_param.addParameter('dose', 0, @isnumeric) %total electron dose in # of electrons per angstroms^2
+    parse_param.addParameter('voltage', 80, @isnumeric)  %beam voltage in keV
+    parse_param.addParameter('alpha_max', 20, @isnumeric)  %semi-convergence angle in mrads
+
+    % object parameters
+    parse_param.addParameter('object', 0, @isnumeric)  %complex object function
+    parse_param.addParameter('dx', 0.1, @isnumeric)  %real-space pixel size in angstroms
+
+    % probe parameters
+    parse_param.addParameter('probe_df', 0, @isnumeric) % defocus in  angstroms
+    parse_param.addParameter('probe_c3', 0, @isnumeric) % spherical aberrations in angstroms
+    parse_param.addParameter('probe_c5', 0, @isnumeric )
+    parse_param.addParameter('probe_c7', 0, @isnumeric )
+    parse_param.addParameter('probe_f_a2', 0, @isnumeric )
+    parse_param.addParameter('probe_theta_a2', 0, @isnumeric )
+    parse_param.addParameter('probe_f_a3', 0, @isnumeric )
+    parse_param.addParameter('probe_theta_a3', 0, @isnumeric )
+    parse_param.addParameter('probe_f_c3', 0, @isnumeric )
+    parse_param.addParameter('probe_theta_c3', 0, @isnumeric )
+    
+    % 
+    parse_param.addParameter('gpu_id', 1, @isnumeric )
+
+    % simulation parameters
+    %parse_param.addParameter('N_data', 1, @isnumeric) % number of datasets to be simulated
+
+    parse_param.parse(param)
+    param_input = parse_param.Results;
+    
+    %% check inputs
+    assert(~isempty(param_input.output_path), 'Output path cannot be empty!')
+
+    assert(param_input.N_dp>0, 'Invalid diffraction pattern size!')
+    assert(param_input.field_of_view>0, 'Invalid scan field of view!')
+    assert(param_input.scan_step_size>0, 'Invalid scan step size!')
+    assert(param_input.voltage>0, 'Invalid voltage!')
+    assert(param_input.alpha_max>0, 'Invalid aperature size!')
+    assert(param_input.dose>0, 'Invalid dose level!')
+
+    field_of_view = param_input.field_of_view;
+    N_dp = param_input.N_dp;
+    N_dp_orig = param_input.N_dp_orig;
+    scan_step_size = param_input.scan_step_size;
+    max_position_error = param_input.max_position_error;
+    
+    dose = param_input.dose;
+    dx = param_input.dx;
+    
+    %gpuDevice(param_input.gpu_id);
+    %% prepare parameters    
+    N_scans_h = ceil(field_of_view/scan_step_size); % number of scan positions along horizontal direction
+    N_scans_v = ceil(field_of_view/scan_step_size); % number of scan positions along vertical direction
+
+    Nc_avg = dose*scan_step_size^2/N_dp^2; %average electron count per detector pixel. For poisson noise, SNR = sqrt(Nc_avg);
+
+    N_obj = size(param_input.object);
+    ind_obj_center = floor(N_obj/2)+1;
+
+    %object = gpuArray(param_input.object);
+    object = param_input.object;
+
+    %% generate probe function
+    %disp('Generate probe function...')
+    par_probe = {};
+    par_probe.df = param_input.probe_df; %defocus in angstrom
+    par_probe.C3 = param_input.probe_c3; %third-order spherical aberration in angstrom
+    par_probe.C5 = param_input.probe_c5; %fifth-order spherical aberration in angstrom
+    par_probe.f_a2 = param_input.probe_f_a2; %azimuthal orientation in radian
+    par_probe.theta_a2 = param_input.probe_theta_a2; %twofold astigmatism in angstrom
+    par_probe.f_a3 = param_input.probe_f_a3; %threefold astigmatism in angstrom
+    par_probe.theta_a3 = param_input.probe_theta_a3; %azimuthal orientation in radian
+
+    par_probe.voltage = param_input.voltage; %beam voltage in keV
+    par_probe.alpha_max = param_input.alpha_max; %semi-convergence angle in mrad
+    par_probe.plotting = false;
+    dk = 1/dx/N_dp_orig; %fourier-space pixel size in 1/A
+
+    [probe_true, ~] = make_tem_probe(dx, N_dp_orig, par_probe);
+	%probe_true = gpuArray(probe_true);
+
+    %% save initial probe and parameters
+    probe = crop_pad(probe_true, [N_dp, N_dp]);
+    if ~exist(param_input.output_path, 'dir'); mkdir(param_input.output_path); end
+    
+    p = {};
+    p.binning = false;
+    p.detector.binning = false;
+    p.dk = dk*N_dp_orig/N_dp;
+    p.N_scans_h = N_scans_h;
+    p.N_scans_v = N_scans_v;
+    save(fullfile(param_input.output_path,'init_probe'),'probe','p','par_probe')
+
+    %% Generate scan positions
+    pos_h = (1+(0:N_scans_h-1)*param_input.scan_step_size);
+    pos_v = (1+(0:N_scans_v-1)*param_input.scan_step_size);
+    % centre this
+    pos_h  = pos_h - (mean(pos_h));
+    pos_v  = pos_v - (mean(pos_v));
+    [Y,X] = meshgrid(pos_h, pos_v);
+    Y = Y';
+    X = X';
+    pos_true_h = X(:); % true posoition
+    pos_true_v = Y(:);
+
+    %pos_recon_init_h = pos_true_h;
+    %pos_recon_init_v = pos_true_v;
+
+    %add random position errors - to simulate scan noise
+    pos_true_h = pos_true_h + max_position_error*(rand(size(pos_true_h))*2-1);
+    pos_true_v = pos_true_v + max_position_error*(rand(size(pos_true_v))*2-1);
+
+    %
+    %calculate indicies for all scans
+    N_scan = length(pos_true_h);
+    %position = pi(integer) + pf(fraction)
+    pv_i = round(pos_true_v/dx);
+    pv_f = pos_true_v - pv_i*dx;
+    ph_i = round(pos_true_h/dx);
+    ph_f = pos_true_h - ph_i*dx;
+
+    ind_h_lb = ph_i - floor(N_dp_orig/2) + ind_obj_center(2);
+    ind_h_ub = ph_i + ceil(N_dp_orig/2) -1 + ind_obj_center(2);
+    ind_v_lb = pv_i - floor(N_dp_orig/2) + ind_obj_center(1);
+    ind_v_ub = pv_i + ceil(N_dp_orig/2) -1 + ind_obj_center(1);
+    
+    %% generate diffraction patterns
+    %dp = gpuArray(zeros(N_dp, N_dp, N_scan));
+    dp = zeros(N_dp, N_dp, N_scan);
+    %snr = ones(N_scan, 1)*inf; %signal-to-noise ratio of each diffraction pattern
+
+    for i=1:N_scan
+        probe_s = shift(probe_true, dx, dx, ph_f(i), pv_f(i));
+        object_roi = object(ind_v_lb(i):ind_v_ub(i),ind_h_lb(i):ind_h_ub(i));
+        psi =  object_roi .* probe_s;
+
+        %FFT to get diffraction pattern
+        dp_true = abs(fftshift(fft2(ifftshift(psi)))).^2;
+        %dp(:,:,i) = dp_true(:,:,i);
+
+        dp_true = imresize(dp_true, N_dp/N_dp_orig, 'box');
+        dp_true(dp_true<0) = 0;
+        dp_temp = dp_true;
+        
+        %Add poisson noise
+        if Nc_avg<inf
+            dp_temp = dp_true/sum(dp_true(:))*(N_dp^2*Nc_avg);
+            
+            dp_temp = poissrnd(dp_temp);
+            
+            dp_temp = dp_temp*sum(dp_true(:))/(N_dp^2*Nc_avg);
+            %snr(i) = mean((dp_true(:)))/std(dp_true(:) - dp_temp(:));
+        end
+        
+        dp(:,:,i) = dp_temp;
+    end
+    
+    %dp = gather(dp);
+
+    % save diffraction patterns 
+    %save_dir = fullfile(base_path, data_path, strcat('data',num2str(j)));
+    if ~exist(param_input.output_path, 'dir'); mkdir(param_input.output_path); end
+    
+    save_name = strcat('data_roi0_dp.hdf5'); %save diffraction patterns
+    %save_name = strcat('data_roi0_dp.h5'); %save diffraction patterns
+    if isfile(fullfile(param_input.output_path,save_name))  
+        delete(fullfile(param_input.output_path,save_name));
+    end
+    h5create(fullfile(param_input.output_path,save_name), '/dp', size(dp), 'ChunkSize',[size(dp,1) size(dp,1), 1], 'Deflate',4)
+    h5write(fullfile(param_input.output_path,save_name), '/dp', dp)
+
+    save_name = strcat('data_roi0_para.hdf5'); %save scan positions
+    if isfile(fullfile(param_input.output_path,save_name))  
+        delete(fullfile(param_input.output_path,save_name));
+    end
+    h5create(fullfile(param_input.output_path,save_name), '/ppX', size(pos_true_h))
+    h5write(fullfile(param_input.output_path,save_name), '/ppX', pos_true_h)
+    h5create(fullfile(param_input.output_path,save_name), '/ppY', size(pos_true_v))
+    h5write(fullfile(param_input.output_path,save_name), '/ppY', pos_true_v)
+
+end

--- a/ptycho/sim_electron_ptycho_recon.m
+++ b/ptycho/sim_electron_ptycho_recon.m
@@ -1,0 +1,202 @@
+% Wrapper function for simulating electron ptychography data and evaluating
+% its reconstruction quality
+% Can be used with BO-GP to find optimal experimental conditions or reconstruction parameters
+% Examples: https://doi.org/10.1038/s41598-022-16041-5
+
+function [recon_score] = sim_electron_ptycho_recon(params, varargin)
+
+    parser = inputParser;
+    %experimental parameters
+    parser.addParameter('field_of_view',  60 , @isnumeric) %scan field of view in angstroms
+    parser.addParameter('scan_step_size',  4 , @isnumeric)  %scan step size in angstroms
+    parser.addParameter('dose',  1e6 , @isnumeric)  %total electron dose (e/A^2)
+    parser.addParameter('N_dp',  128 , @isnumeric)  %size of experimental diffraction pattern in pixels
+    parser.addParameter('N_dp_orig',  1024 , @isnumeric)  %size of true diffraction pattern in pixels
+    parser.addParameter('max_position_error',  0 , @isnumeric)  %max scan position error in angstroms
+    parser.addParameter('voltage',  80 , @isnumeric)  %beam voltage in kV
+
+    % probe parameters 
+    parser.addParameter('alpha_max',  0 , @isnumeric) %aperture size in mrad
+    parser.addParameter('df', 0 , @isnumeric ) %defocus in nanometers
+    parser.addParameter('cs', 0 , @isnumeric ) %third-order spherical aberration in millimeters 
+    parser.addParameter('c5', 0 , @isnumeric ) %fifth-order spherical aberration in meters
+    parser.addParameter('c7', 0 , @isnumeric ) %seventh-order spherical aberration in meters
+    parser.addParameter('f_a2', 0 , @isnumeric ) %twofold astigmatism in nanometers
+    parser.addParameter('theta_a2', 0 , @isnumeric ) %twofold azimuthal orientation in radian
+    parser.addParameter('f_a3', 0 , @isnumeric ) %threefold astigmatism in micrometers
+    parser.addParameter('theta_a3', 0 , @isnumeric ) %threefold azimuthal orientation in radian
+
+    % reconstruction parameters 
+    parser.addParameter('eng_name', 'GPU', @ischar)
+    parser.addParameter('Niter', 1000, @isnumeric)
+    parser.addParameter('Niter_save_results_every', 1000, @isnumeric)
+    parser.addParameter('Nprobe', 1, @isnumeric)
+    parser.addParameter('grouping', 100, @isnumeric)
+    parser.addParameter('method',  'MLs', @ischar)
+    parser.addParameter('momentum',  0, @isnumeric)
+    parser.addParameter('opt_errmetric',  'L1', @ischar)
+    parser.addParameter('apply_multimodal_update', 0, @islogical)
+    parser.addParameter('probe_position_search', inf, @isnumeric)
+
+    parser.addParameter('GPU_list', 1 , @isnumeric ) %GPU IDs for reconstruction
+
+    % evaluation parameters 
+    parser.addParameter('metric', 'ssim', @ischar)
+    parser.addParameter('crop_x', 0, @isnumeric)
+    parser.addParameter('crop_y', 0, @isnumeric)
+    parser.addParameter('ground_truth_recon', '', @ischar)
+
+    parser.parse(varargin{:})
+    r = parser.Results;
+
+    % load all to the param structure 
+    par = params; 
+    for name = fieldnames(r)'
+        if ~isfield(par, name{1}) || ~ismember(name, parser.UsingDefaults) % prefer values in param structure 
+            par.(name{1}) = r.(name{1});
+        end
+    end
+    
+    %% check inputs
+    assert(~isempty(par.ground_truth_recon), 'Ground truth recon file cannot be empty!')
+
+    %% initialize parameters
+    base_path = par.base_path;
+    par_sim = {}; % for simulation function
+    par_sim.field_of_view = par.field_of_view; %scan field of view in angstroms
+    par_sim.scan_step_size = par.scan_step_size; %scan step size in angstroms
+    par_sim.dose = par.dose; %total electron dose (e/A^2)
+    par_sim.N_dp = par.N_dp; %size of experimental diffraction pattern in pixels
+    par_sim.N_dp_orig = par.N_dp_orig; %size of true diffraction pattern in pixels
+    par_sim.max_position_error = par.max_position_error; %max scan position error in angstroms
+    par_sim.voltage = par.voltage; %beam voltage in kV
+
+    par_sim.alpha_max = par.alpha_max; %mrad
+    par_sim.probe_df = par.df*10; %angstrom
+    par_sim.probe_c3 = par.cs*1e-3/1e-10; %angstrom
+    par_sim.probe_c5 = par.c5/1e-10; %angstrom
+    par_sim.probe_c7 = par.c7/1e-10; %angstrom
+    par_sim.probe_f_a2 = par.f_a2*10; %angstrom
+    par_sim.probe_theta_a2 = par.theta_a2; %rad
+    par_sim.probe_f_a3 = par.f_a3*1e-6/1e-10; %angstrom
+    par_sim.probe_theta_a3 = par.theta_a3; %rad
+
+    data_path = generate_data_path(par.base_data_path, varargin);
+    par_sim.output_path = fullfile(base_path, data_path, 'data1');
+    par_sim.dx = par.dx;
+    par_sim.object = par.object_true;
+
+    if length(par.GPU_list)>1 %assume parallel processing
+        t = getCurrentTask;
+        t = t.ID;
+        gpu_id = par.GPU_list(t);
+    else
+        gpu_id = par.GPU_list;
+    end
+    par_sim.gpu_id = gpu_id;
+
+    %% start simulation
+    disp('Simulate diffraction patterns...')
+
+    [~, ~, p] = sim_electron_cbed(par_sim);
+
+    disp('Simulate diffraction patterns...done')
+
+    %% run ptycho recon
+    disp('Reconstruction...')
+    par_recon = {};
+    par_recon.Niter = par.Niter;
+    par_recon.Niter_save_results_every =  par.Niter_save_results_every;
+    par_recon.Nprobe = par.Nprobe;
+    par_recon.grouping = par.grouping;
+    par_recon.gpu_id = gpu_id;
+
+    par_recon.method = par.method;
+    par_recon.verbose_level = 0;
+
+    par_recon.scan_number = 1;
+    par_recon.beam_source = 'electron';
+
+    par_recon.Ndp = par_sim.N_dp;
+    par_recon.base_path = fullfile(base_path, data_path,'/');
+    par_recon.cen_dp_y = floor(par_recon.Ndp/2)+1;
+    par_recon.cen_dp_x = floor(par_recon.Ndp/2)+1;
+
+    par_recon.initial_probe_file = fullfile(par_sim.output_path, 'init_probe.mat');
+    par_recon.energy = par_sim.voltage;
+    par_recon.dk = p.dk; %calculated in sim_electron_cbed
+    par_recon.scan_format = 'data%d';
+    par_recon.scan_string_format = 'data%d';
+    par_recon.roi_label = '0';
+
+    par_recon.detector_name = 'empad';
+    par_recon.data_preparator = 'matlab_aps';
+
+    par_recon.src_positions =  'hdf5_pos';
+    par_recon.scan_type = 'default';
+
+    par_recon.output_dir_base = fullfile(base_path, data_path, '/');
+
+    [~, eng, ~] = ptycho_recon(par_recon);
+    disp('Reconstruction...done')
+
+    %% evaluate ptycho recon
+    disp('Evaluate reconstruction...')
+    par_eval = {};
+    par_eval.file1 = fullfile(eng.fout, sprintf('Niter%d.mat', par_recon.Niter));
+	par_eval.file2 = par.ground_truth_recon;
+    
+    par_eval.crop_y = par.crop_y;
+    par_eval.crop_x = par.crop_x;
+    
+    par_eval.electron = true;
+    par_eval.verbose_level = 0;
+    par_eval.metric = par.metric;
+    recon_score = compare_two_ptycho_recons(par_eval);
+
+    switch par_eval.metric
+        case 'frc_1bit'
+        otherwise
+            recon_score = 1 - recon_score;
+    end
+    disp('Evaluate reconstruction...done')
+    
+end
+
+function [base_path] = generate_data_path(base_path, param_var)
+
+    for i=1:2:length(param_var)
+        switch param_var{i}
+            case 'alpha_max'
+                par_format = '_alpha%0.2fmrad';
+            case 'df'
+                par_format = '_df%0.2fnm';
+            case 'cs'
+                par_format = '_cs%0.2fmm';
+            case 'c5'
+                par_format = '_c5%0.2fm';
+            case 'c7'
+                par_format = '_c7%0.2fm';
+            case 'fa2'
+                par_format = '_fa2_%0.2fnm';
+            case 'theta_a2'
+                par_format = '_theta_a2_%0.2frad';
+            case 'fa3'
+                par_format = '_fa3_%0.2fum';
+            case 'theta_a3'
+                par_format = '_theta_a3_%0.2frad';
+            case 'Ndp'
+                par_format = '_Ndp%d';
+            case 'N_dp_orig'
+                par_format = '_Ndp_orig%d';
+            case 'scan_step_size'
+                par_format = '_stepsize%0.1fA';
+            case 'dose'
+                par_format = '_dose%d';
+            otherwise
+                par_format = ['_', param_var{i}, '%d'];
+        end
+        base_path = sprintf([base_path, par_format], param_var{i+1});
+    end    
+end
+


### PR DESCRIPTION
Added wrapper functions that simulate electron ptychography data and evaluate its reconstruction quality.
They can be used with BO-GP to find optimal experimental conditions or reconstruction parameters.
Example scripts will be added to /fold_slice/ptycho/examples in the near future.
