### PR TITLE
save ptychographic reconstructions that are larger than 2GB

### DIFF
--- a/ptycho/+engines/+GPU/ptycho_solver.m
+++ b/ptycho/+engines/+GPU/ptycho_solver.m
@@ -625,7 +625,7 @@ while iter <= par.number_iterations %modified by YJ: use while loop for time-res
         if par.save_init_probe
             p.init_probe = probe_init; %store initial probe (after init_solver.m's pre-processing)
         end
-        save(strcat(par.fout,'Niter',num2str(iter),'.mat'),'outputs','p','probe','object');
+        save(strcat(par.fout, 'Niter', num2str(iter), '.mat'), 'outputs', 'p', 'probe', 'object', "-v7.3");
         
         %% save object phase
         if any(ismember({'obj_ph','obj_ph_sum','obj_ph_stack'}, par.save_images))

--- a/ptycho/+engines/+GPU_MS/ptycho_solver.m
+++ b/ptycho/+engines/+GPU_MS/ptycho_solver.m
@@ -655,7 +655,7 @@ for iter =  (1-par.initial_probe_rescaling):par.number_iterations
         if par.save_init_probe
             p.init_probe = probe_init; %store initial probe (after init_solver.m's pre-processing)
         end
-        save(strcat(par.fout,'Niter',num2str(iter),'.mat'),'outputs','p','probe','object');
+        save(sprintf([par.fout, 'Niter%d.mat'], iter), 'outputs', 'p', 'probe', 'object', "-v7.3");
         
         %% save object phase
         if any(ismember({'obj_ph','obj_ph_sum','obj_ph_stack'}, par.save_images))


### PR DESCRIPTION
Allow users to save ptychographic reconstructions that are larger than 2GB. 
For reference, see https://www.mathworks.com/help/matlab/ref/save.html#btox10b-1-version.
This could be useful for multislice reconstructions or large FOV datasets.