### PR TITLE
fix a bug that dk is initialized to 0 when using the wrapper function

### DIFF
--- a/ptycho/+core/initialize_ptycho.m
+++ b/ptycho/+core/initialize_ptycho.m
@@ -89,9 +89,9 @@ else
     % standard farfield ptychography
     % modified by YJ for electron pty
     if isfield(p,'beam_source') && strcmp(p.beam_source, 'electron')
-        if isfield(p,'dk')  %A^-1/pix 
+        if isfield(p,'dk') && p.dk>0 %A^-1/pix
             p.dx_spec = 1./p.asize./p.dk; %angstrom
-        elseif isfield(p,'d_alpha') % mrad/pix
+        elseif isfield(p,'d_alpha') && p.d_alpha>0 %mrad/pix
             p.dx_spec = 1./p.asize./(p.d_alpha/1e3/p.lambda); %angstrom
         else
             error('dk or d_alpha are not speficied!')

--- a/ptycho/examples/README.txt
+++ b/ptycho/examples/README.txt
@@ -4,19 +4,18 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXX Copy matlab scripts to /fold_slice/ptycho/ before use XXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-1. mixed_state_electron_ptycho_nat_comm:
+1. MoSe2_nat_comm: 
 Single-slice electron ptychography on an experimental data of bilayer MoSe2. Published in
 Chen, Z., Odstrcil, M., Jiang, Y. et al. Mixed-state electron ptychography enables sub-angstrom resolution imaging with picometer precision at low dose. Nat Commun 11, 2994 (2020). https://doi.org/10.1038/s41467-020-16688-6
 
-2. multislice_electron_ptycho_science:
+2. PSO_science: 
 Multislice electron ptychography on an experimental data of thick PSO. Published in
-Zhen Chen et al. ,Electron ptychography achieves atomic-resolution limits set by lattice vibrations. Science 372,826-831(2021). DOI:10.1126/science.abg2533
+Zhen Chen et al. ,Electron ptychography achieves atomic-resolution limits set by lattice vibrations.Science372,826-831(2021).DOI:10.1126/science.abg2533
 
-3. auto_param_tuning_sci_rep:
+3. MoS2_sci_rep:
 Automatic parameter optimization for simulated bilayer MoS2 structure. Published in
 Cao, M.C., Chen, Z., Jiang, Y. et al. Automatic parameter selection for electron ptychography via Bayesian optimization. Sci Rep 12, 12284 (2022). https://doi.org/10.1038/s41598-022-16041-5
 
-4. uncorrected_electron_ptycho_science:
-High-resolution electron ptychography of 2D materials using an uncorrected microscope. Published in
-Kayla X. Nguyen et al.,Achieving sub-0.5-angstrom–resolution ptychography in an uncorrected electron microscope. Science 383,865-870(2024). DOI:10.1126/science.adl2029
+
+
 

--- a/ptycho/examples/README.txt
+++ b/ptycho/examples/README.txt
@@ -4,18 +4,19 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXX Copy matlab scripts to /fold_slice/ptycho/ before use XXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-1. MoSe2_nat_comm: 
+1. mixed_state_electron_ptycho_nat_comm:
 Single-slice electron ptychography on an experimental data of bilayer MoSe2. Published in
 Chen, Z., Odstrcil, M., Jiang, Y. et al. Mixed-state electron ptychography enables sub-angstrom resolution imaging with picometer precision at low dose. Nat Commun 11, 2994 (2020). https://doi.org/10.1038/s41467-020-16688-6
 
-2. PSO_science: 
+2. multislice_electron_ptycho_science:
 Multislice electron ptychography on an experimental data of thick PSO. Published in
-Zhen Chen et al. ,Electron ptychography achieves atomic-resolution limits set by lattice vibrations.Science372,826-831(2021).DOI:10.1126/science.abg2533
+Zhen Chen et al. ,Electron ptychography achieves atomic-resolution limits set by lattice vibrations. Science 372,826-831(2021). DOI:10.1126/science.abg2533
 
-3. MoS2_sci_rep:
+3. auto_param_tuning_sci_rep:
 Automatic parameter optimization for simulated bilayer MoS2 structure. Published in
 Cao, M.C., Chen, Z., Jiang, Y. et al. Automatic parameter selection for electron ptychography via Bayesian optimization. Sci Rep 12, 12284 (2022). https://doi.org/10.1038/s41598-022-16041-5
 
-
-
+4. uncorrected_electron_ptycho_science:
+High-resolution electron ptychography of 2D materials using an uncorrected microscope. Published in
+Kayla X. Nguyen et al.,Achieving sub-0.5-angstrom–resolution ptychography in an uncorrected electron microscope. Science 383,865-870(2024). DOI:10.1126/science.adl2029
 


### PR DESCRIPTION
Fix a bug in that the pixel size of diffraction patterns (dk) is initialized incorrectly when using the wrapper function (ptych_recon).